### PR TITLE
chore: sync documentation fixes from main

### DIFF
--- a/.agents/agentdb-state-manager/CLAUDE.md
+++ b/.agents/agentdb-state-manager/CLAUDE.md
@@ -6,7 +6,7 @@ purpose: Persistent state management using AgentDB (DuckDB) for workflow state t
 Tracks workflow transitions via slash command invocations.
 
 **Primary purpose:** Workflow state tracking and analytics
-parent: null
+parent: ../CLAUDE.md
 sibling_readme: README.md
 children:
   - ARCHIVED/CLAUDE.md

--- a/.agents/bmad-planner/CLAUDE.md
+++ b/.agents/bmad-planner/CLAUDE.md
@@ -2,7 +2,7 @@
 type: claude-context
 directory: .claude/skills/bmad-planner
 purpose: BMAD Planner provides an **interactive callable tool** for creating planning documents in the main repository on contrib branches. It implements Phase 1 (Planning) of the workflow, generating comprehensive requirements, architecture, and epic breakdown through a three-persona interactive Q&A system.
-parent: null
+parent: ../CLAUDE.md
 sibling_readme: README.md
 children:
   - ARCHIVED/CLAUDE.md

--- a/.agents/git-workflow-manager/CLAUDE.md
+++ b/.agents/git-workflow-manager/CLAUDE.md
@@ -2,7 +2,7 @@
 type: claude-context
 directory: .claude/skills/git-workflow-manager
 purpose: Git Workflow Manager provides **automated git operations** for the git-flow + GitHub-flow hybrid workflow with worktrees. It handles branch creation, worktree management, commits, PRs, semantic versioning, and daily rebase operations. All operations are designed to work with the isolated worktree development pattern and VCS provider abstraction (GitHub/Azure DevOps).
-parent: null
+parent: ../CLAUDE.md
 sibling_readme: README.md
 children:
   - ARCHIVED/CLAUDE.md

--- a/.agents/initialize-repository/CLAUDE.md
+++ b/.agents/initialize-repository/CLAUDE.md
@@ -2,7 +2,7 @@
 type: claude-context
 directory: .claude/skills/initialize-repository
 purpose: Initialize-repository is a **meta-skill (Phase 0)** that bootstraps new repositories with the complete workflow system. It provides an interactive callable tool for replicating skills, documentation, and standards from a source repository to a new target repository. Unlike other skills that operate within a repository, this meta-skill operates across repositories (source → target) and is used once per new project.
-parent: null
+parent: ../CLAUDE.md
 sibling_readme: README.md
 children:
   - ARCHIVED/CLAUDE.md

--- a/.agents/quality-enforcer/CLAUDE.md
+++ b/.agents/quality-enforcer/CLAUDE.md
@@ -2,7 +2,7 @@
 type: claude-context
 directory: .claude/skills/quality-enforcer
 purpose: Quality Enforcer provides **automated quality gate enforcement** for the workflow. It runs tests, checks coverage, validates linting, type checking, and builds before allowing PR creation. Enforces minimum 80% test coverage and all tests passing. Integrates with git-workflow-manager for semantic versioning.
-parent: null
+parent: ../CLAUDE.md
 sibling_readme: README.md
 children:
   - ARCHIVED/CLAUDE.md

--- a/.agents/speckit-author/CLAUDE.md
+++ b/.agents/speckit-author/CLAUDE.md
@@ -2,7 +2,7 @@
 type: claude-context
 directory: .claude/skills/speckit-author
 purpose: SpecKit Author provides **interactive callable tools** for creating and managing specifications in feature/release/hotfix worktrees. It implements the SpecKit phase of the workflow, generating detailed specifications (spec.md) and implementation plans (plan.md) through interactive Q&A sessions.
-parent: null
+parent: ../CLAUDE.md
 sibling_readme: README.md
 children:
   - ARCHIVED/CLAUDE.md

--- a/.agents/tech-stack-adapter/CLAUDE.md
+++ b/.agents/tech-stack-adapter/CLAUDE.md
@@ -2,7 +2,7 @@
 type: claude-context
 directory: .claude/skills/tech-stack-adapter
 purpose: Tech Stack Adapter provides **automatic project detection** for Python/uv projects. It reads `pyproject.toml`, detects installed dependencies and tools, and generates appropriate commands for testing, building, coverage, database migrations, and containerization. Enables workflow to adapt to different project configurations without hardcoded assumptions.
-parent: null
+parent: ../CLAUDE.md
 sibling_readme: README.md
 children:
   - ARCHIVED/CLAUDE.md

--- a/.agents/workflow-orchestrator/CLAUDE.md
+++ b/.agents/workflow-orchestrator/CLAUDE.md
@@ -2,7 +2,7 @@
 type: claude-context
 directory: .claude/skills/workflow-orchestrator
 purpose: Workflow Orchestrator is **the main coordinator skill** for the 7-phase workflow system. Unlike other skills, it contains no executable scripts - instead, it provides algorithmic guidance for Claude Code to detect workflow context, determine current phase, load appropriate skills dynamically, and manage context usage. This is a **conceptual skill** that directs Claude's behavior rather than providing callable tools.
-parent: null
+parent: ../CLAUDE.md
 sibling_readme: README.md
 children:
   - ARCHIVED/CLAUDE.md

--- a/.agents/workflow-utilities/CLAUDE.md
+++ b/.agents/workflow-utilities/CLAUDE.md
@@ -2,7 +2,7 @@
 type: claude-context
 directory: .claude/skills/workflow-utilities
 purpose: Workflow Utilities provides **shared utilities** for all workflow skills. It includes file deprecation, directory structure creation, CLAUDE.md hierarchy management, VCS abstraction (GitHub/Azure DevOps), documentation maintenance tools, and version validation. All other skills depend on workflow-utilities for consistent file operations.
-parent: null
+parent: ../CLAUDE.md
 sibling_readme: README.md
 children:
   - ARCHIVED/CLAUDE.md

--- a/.claude/skills/agentdb-state-manager/CLAUDE.md
+++ b/.claude/skills/agentdb-state-manager/CLAUDE.md
@@ -6,7 +6,7 @@ purpose: Persistent state management using AgentDB (DuckDB) for workflow state t
 Tracks workflow transitions via slash command invocations.
 
 **Primary purpose:** Workflow state tracking and analytics
-parent: null
+parent: ../CLAUDE.md
 sibling_readme: README.md
 children:
   - ARCHIVED/CLAUDE.md

--- a/.claude/skills/bmad-planner/CLAUDE.md
+++ b/.claude/skills/bmad-planner/CLAUDE.md
@@ -2,7 +2,7 @@
 type: claude-context
 directory: .claude/skills/bmad-planner
 purpose: BMAD Planner provides an **interactive callable tool** for creating planning documents in the main repository on contrib branches. It implements Phase 1 (Planning) of the workflow, generating comprehensive requirements, architecture, and epic breakdown through a three-persona interactive Q&A system.
-parent: null
+parent: ../CLAUDE.md
 sibling_readme: README.md
 children:
   - ARCHIVED/CLAUDE.md

--- a/.claude/skills/git-workflow-manager/CLAUDE.md
+++ b/.claude/skills/git-workflow-manager/CLAUDE.md
@@ -2,7 +2,7 @@
 type: claude-context
 directory: .claude/skills/git-workflow-manager
 purpose: Git Workflow Manager provides **automated git operations** for the git-flow + GitHub-flow hybrid workflow with worktrees. It handles branch creation, worktree management, commits, PRs, semantic versioning, and daily rebase operations. All operations are designed to work with the isolated worktree development pattern and VCS provider abstraction (GitHub/Azure DevOps).
-parent: null
+parent: ../CLAUDE.md
 sibling_readme: README.md
 children:
   - ARCHIVED/CLAUDE.md

--- a/.claude/skills/initialize-repository/CLAUDE.md
+++ b/.claude/skills/initialize-repository/CLAUDE.md
@@ -2,7 +2,7 @@
 type: claude-context
 directory: .claude/skills/initialize-repository
 purpose: Initialize-repository is a **meta-skill (Phase 0)** that bootstraps new repositories with the complete workflow system. It provides an interactive callable tool for replicating skills, documentation, and standards from a source repository to a new target repository. Unlike other skills that operate within a repository, this meta-skill operates across repositories (source → target) and is used once per new project.
-parent: null
+parent: ../CLAUDE.md
 sibling_readme: README.md
 children:
   - ARCHIVED/CLAUDE.md

--- a/.claude/skills/quality-enforcer/CLAUDE.md
+++ b/.claude/skills/quality-enforcer/CLAUDE.md
@@ -2,7 +2,7 @@
 type: claude-context
 directory: .claude/skills/quality-enforcer
 purpose: Quality Enforcer provides **automated quality gate enforcement** for the workflow. It runs tests, checks coverage, validates linting, type checking, and builds before allowing PR creation. Enforces minimum 80% test coverage and all tests passing. Integrates with git-workflow-manager for semantic versioning.
-parent: null
+parent: ../CLAUDE.md
 sibling_readme: README.md
 children:
   - ARCHIVED/CLAUDE.md

--- a/.claude/skills/speckit-author/CLAUDE.md
+++ b/.claude/skills/speckit-author/CLAUDE.md
@@ -2,7 +2,7 @@
 type: claude-context
 directory: .claude/skills/speckit-author
 purpose: SpecKit Author provides **interactive callable tools** for creating and managing specifications in feature/release/hotfix worktrees. It implements the SpecKit phase of the workflow, generating detailed specifications (spec.md) and implementation plans (plan.md) through interactive Q&A sessions.
-parent: null
+parent: ../CLAUDE.md
 sibling_readme: README.md
 children:
   - ARCHIVED/CLAUDE.md

--- a/.claude/skills/tech-stack-adapter/CLAUDE.md
+++ b/.claude/skills/tech-stack-adapter/CLAUDE.md
@@ -2,7 +2,7 @@
 type: claude-context
 directory: .claude/skills/tech-stack-adapter
 purpose: Tech Stack Adapter provides **automatic project detection** for Python/uv projects. It reads `pyproject.toml`, detects installed dependencies and tools, and generates appropriate commands for testing, building, coverage, database migrations, and containerization. Enables workflow to adapt to different project configurations without hardcoded assumptions.
-parent: null
+parent: ../CLAUDE.md
 sibling_readme: README.md
 children:
   - ARCHIVED/CLAUDE.md

--- a/.claude/skills/workflow-orchestrator/CLAUDE.md
+++ b/.claude/skills/workflow-orchestrator/CLAUDE.md
@@ -2,7 +2,7 @@
 type: claude-context
 directory: .claude/skills/workflow-orchestrator
 purpose: Workflow Orchestrator is **the main coordinator skill** for the 7-phase workflow system. Unlike other skills, it contains no executable scripts - instead, it provides algorithmic guidance for Claude Code to detect workflow context, determine current phase, load appropriate skills dynamically, and manage context usage. This is a **conceptual skill** that directs Claude's behavior rather than providing callable tools.
-parent: null
+parent: ../CLAUDE.md
 sibling_readme: README.md
 children:
   - ARCHIVED/CLAUDE.md

--- a/.claude/skills/workflow-utilities/CLAUDE.md
+++ b/.claude/skills/workflow-utilities/CLAUDE.md
@@ -2,7 +2,7 @@
 type: claude-context
 directory: .claude/skills/workflow-utilities
 purpose: Workflow Utilities provides **shared utilities** for all workflow skills. It includes file deprecation, directory structure creation, CLAUDE.md hierarchy management, VCS abstraction (GitHub/Azure DevOps), documentation maintenance tools, and version validation. All other skills depend on workflow-utilities for consistent file operations.
-parent: null
+parent: ../CLAUDE.md
 sibling_readme: README.md
 children:
   - ARCHIVED/CLAUDE.md

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -8,6 +8,7 @@ children:
   - archived/CLAUDE.md
   - guides/CLAUDE.md
   - reference/CLAUDE.md
+  - research/CLAUDE.md
 ---
 
 # Claude Code Context: docs
@@ -29,3 +30,4 @@ Documentation root for guides, references, and archives.
 - **archived**: [archived/CLAUDE.md](archived/CLAUDE.md)
 - **guides**: [guides/CLAUDE.md](guides/CLAUDE.md)
 - **reference**: [reference/CLAUDE.md](reference/CLAUDE.md)
+- **research**: [research/CLAUDE.md](research/CLAUDE.md)

--- a/docs/research/CLAUDE.md
+++ b/docs/research/CLAUDE.md
@@ -1,0 +1,34 @@
+---
+type: claude-context
+directory: docs/research
+purpose: Research reports and analysis documents for AI agent workflows, architectures, and tooling.
+parent: ../CLAUDE.md
+sibling_readme: null
+children:
+  []
+---
+
+# Claude Code Context: research
+
+## Purpose
+
+Research reports and analysis documents for AI agent workflows, architectures, and tooling.
+
+## Contents
+
+- `10_report-autogen-dspy-architecture.md` - AutoGen and DSPy architecture analysis
+- `11_report-embedding-model.md` - Embedding model evaluation
+- `12_report-baml-documentation-extractor.md` - BAML documentation extraction
+- `13_report-baml-kuzu-graph-schema.md` - BAML and Kuzu graph schema design
+- `14_report-agents-autogen-bmad-speckit-dspy-baml.md` - Agent framework comparison
+- `15_report-ai-agent-workflow-architecture-optimization.md` - Workflow architecture optimization
+- `16_report-agent-20-30-confit-setup-train-serve.md` - Agent configuration and deployment
+- `17_ai-model-lifecycle-directory-structure.md` - AI model lifecycle organization
+- `18_prompt-complexity-quantification.md` - Prompt complexity metrics
+- `18-1_prompt-complexity-routing-claude-model.md` - Claude model routing by complexity
+- `19_jupyter-to-marimo-conversion-guide.md` - Jupyter to Marimo migration
+- `20_claude-preserve-state-todo-compact.md` - Claude state preservation patterns
+
+## Related
+
+- **Parent**: [docs](../CLAUDE.md)

--- a/specs/STATUS.md
+++ b/specs/STATUS.md
@@ -12,6 +12,9 @@ Track the status of all feature specifications in this repository.
 | 006 | make-the-entire | completed | 2025-11 |
 | 007 | remove-redundant-todo | completed | 2025-11 |
 | 008 | workflow-skill-integration | completed | 2025-11 |
+| 009 | ai-config-architecture-docs | completed | 2025-11 |
+| 010 | ascii-only-output | completed | 2025-11 |
+| 011 | copilot-review-batch-fix | completed | 2025-11 |
 
 ## Status Legend
 


### PR DESCRIPTION
## Summary

Backmerge documentation fixes from main to develop after direct-to-main PR #108.

- Fixed CLAUDE.md hierarchy parent references
- Created docs/research/CLAUDE.md
- Updated specs/STATUS.md with proper IDs

## Test plan

- [x] Documentation-only changes, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)