### PR TITLE
backmerge: v7.2.0 -> develop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "stharrold-templates"
-version = "5.18.0"
+version = "7.2.0"
 description = "Templates and utilities for MCP server configuration and agentic development workflows"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Backmerge release v7.2.0 to develop.

Keeps develop in sync with production.

[BOT] Generated with [Gemini Code](https://gemini.com/gemini-code)