### PR TITLE
backmerge: v7.3.0 -> develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [7.3.0] - 2026-01-18
 
 ### Changed
+- **Workflow** - Archived and removed legacy Gemini GitHub Actions workflows and command configurations.
+
+## [7.2.0] - 2026-01-04
+
+### Changed
 - **Dependencies** - Added `tomlkit` as a development dependency.
 - **Testing** - Updated `test_secrets.py` to use `tmp_path` fixture for better isolation.
-- **Workflow** - Archived and removed legacy Gemini GitHub Actions workflows and command configurations.
+- **Workflow** - Disabled `gemini-dispatch.yml` workflow.
 - **Workflow** - Slash commands and scripts updated to output manual instructions instead of automatic deletion/merging for critical steps.
 - **Documentation** - Updated `GEMINI.md` references.
 - **Documentation** - Updated `WORKFLOW.md`, `GEMINI.md`, and skill docs to reflect manual cleanup workflow.
@@ -773,7 +778,8 @@ Earlier versions (< 5.0.0) used a different workflow architecture. See `ARCHIVED
 
 | Version | Date       | Type  | Description |
 |---------|------------|-------|-------------|
-| 7.3.0   | 2026-01-18 | MINOR | Manual workflow transition + removal of legacy Gemini configs |
+| 7.3.0   | 2026-01-18 | MINOR | Removal of legacy Gemini configs |
+| 7.2.0   | 2026-01-04 | MINOR | Manual workflow transition + disabled dispatch workflow |
 | 7.0.0   | 2026-01-01 | MAJOR | Streamlined for Gemini-only development + removed legacy tools |
 | 1.10.0  | 2025-11-16 | MINOR | MIT Agent Synchronization Pattern (Phase 1) + DuckDB compatibility fixes |
 | 1.9.0   | 2025-11-09 | MINOR | Work-item generation workflow + VCS adapter enhancements |


### PR DESCRIPTION
## Summary

Backmerge release v7.3.0 to develop.

Keeps develop in sync with production.

[BOT] Generated with [Gemini Code](https://gemini.com/gemini-code)