### PR TITLE
backmerge: v8.1.0 -> develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.1.0] - 2026-01-30
+
+### Documentation
+- **CLAUDE.md Gotchas section** — Added operational notes for release workflow, ruff auto-fixes, historical Gemini references, and AgentDB initialization behavior.
+- **PR review fixes** — Corrected stale `gemini mcp` CLI commands, `~/.gemini.json` config paths, and product URLs across 10+ documentation files.
+
 ## [8.0.0] - 2026-01-29
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,14 +17,14 @@ children:
 Gemini Code to Claude Code migration complete (v8.0.0).
 - `.gemini/` → `.claude/`, `GEMINI.md` → `CLAUDE.md` — done
 - Secrets management aligned with `library` repo conventions
-- pyproject.toml version: 8.0.0
+- pyproject.toml version: 8.1.0
 
 ## Gotchas
 
 - `release_workflow.py create-release` auto-calculates version from last git tag — override manually for major bumps
 - Ruff auto-fixes import ordering on commit — re-stage if pre-commit hook modifies files
 - `docs/archived/` and `docs/reference/` preserve historical Gemini references intentionally — do not update
-- `record_sync.py` auto-initializes AgentDB on first use — failures are non-blocking
+- `record_sync.py` auto-initializes AgentDB on first use — initialization failures cause a non-zero exit unless the caller ignores the exit code or handles exceptions
 
 ## Branch Structure
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "stharrold-templates"
-version = "8.0.0"
+version = "8.1.0"
 description = "Templates and utilities for MCP server configuration and agentic development workflows"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Backmerge release v8.1.0 to develop.

Keeps develop in sync with production.

[BOT] Generated with [Claude Code](https://claude.ai/code)