### PR TITLE
backmerge: v8.2.0 -> develop

### DIFF
--- a/.claude/commands/workflow/v7x1_1-worktree.md
+++ b/.claude/commands/workflow/v7x1_1-worktree.md
@@ -15,7 +15,7 @@ argument-hint: "[feature description]"
 Parse "$ARGUMENTS" to create a kebab-case slug (lowercase, hyphens, limit 50 chars).
 
 ## Step 1.5: Detect Contrib Branch
-Detect the contrib branch: run `git branch --list 'contrib/*'` and use the first result (trimmed). If none found, fall back to the current branch.
+Detect the contrib branch: first check if the current branch (`git branch --show-current`) matches `contrib/*` — if so, use it. Otherwise, run `git branch --list 'contrib/*' --sort=-committerdate` and use the first result (most recently updated). If no contrib branches exist, fail with instructions to create one.
 
 ## Step 2: Create Feature Worktree
 Run: `uv run python .claude/skills/git-workflow-manager/scripts/create_worktree.py feature {slug} {contrib_branch}`

--- a/.claude/commands/workflow/v7x1_2-integrate.md
+++ b/.claude/commands/workflow/v7x1_2-integrate.md
@@ -12,7 +12,7 @@ argument-hint: "[feature-branch]"
 - If $ARGUMENTS has branch: Full mode (feature -> contrib PR, cleanup, contrib -> develop PR)
 
 ## Step 0: Detect Contrib Branch
-Detect the contrib branch: run `git branch --list 'contrib/*'` and use the first result (trimmed). If none found, fall back to the current branch.
+Detect the contrib branch: first check if the current branch (`git branch --show-current`) matches `contrib/*` — if so, use it. Otherwise, run `git branch --list 'contrib/*' --sort=-committerdate` and use the first result (most recently updated). If no contrib branches exist, fail with instructions to create one.
 
 ## Step 1: feature -> contrib [FULL MODE]
 Push $ARGUMENTS and create PR to `{contrib_branch}` using `gh pr create`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [8.2.0] - 2026-01-31
 
 ### Changed
-- **Gemini->Claude migration cleanup** (#194) — Replaced remaining Gemini references in WORKFLOW.md, CONTRIBUTING.md, copilot-instructions.md, .gitignore.
-- **Parameterized contrib branch** (#203) — Command .toml files now auto-detect contrib branch via `git branch --list 'contrib/*'` instead of hardcoding `contrib/stharrold`.
+- **Gemini->Claude migration cleanup** (#194) — Replaced remaining Gemini references in WORKFLOW.md, CONTRIBUTING.md, .gitignore, and removed `.github/copilot-instructions.md` (duplicate of root CLAUDE.md).
+- **Parameterized contrib branch** (#203) — Command .md files now auto-detect contrib branch via `git branch --list 'contrib/*'` instead of hardcoding `contrib/stharrold`.
+- **CI review logging** (#205) — Added `show_full_output: true` to Claude Code Review workflow for debugging.
 - **Portable example paths** (#202) — Replaced hardcoded `/Users/stharrold` paths with `~/` in documentation examples.
 - **Removed tools/ ruff config** (#197) — Removed unused `tools/**/*.py` per-file-ignores from pyproject.toml.
 
 ### Added
 - **Quick Reference sections** (#199) — Added Quick Reference to all 6 SKILL.md files for fast command lookup.
-- **Error recovery docs** (#200) — Added error recovery guidance to all 4 workflow command .toml files.
+- **Error recovery docs** (#200) — Added error recovery guidance to all 4 workflow command .md files.
 - **Tech-stack-adapter tests** (#201) — Added 6 smoke tests for detect_stack.py.
 - **Workflow-orchestrator tests** (#201) — Added 7 structure and documentation tests.
 - **Critical assessment** — Added `ARCHIVED/20260131T161758Z_critical-assessment.md` covering 5 audit dimensions.
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - **Archived .gemini-state/** (#195) — Archived legacy Gemini state directory to `ARCHIVED/20260131T161758Z_gemini-state.zip`.
 - **Dead skill links** (#196) — Removed dead `bmad-planner/CLAUDE.md` link from `.claude/skills/CLAUDE.md`.
+- **Local Claude settings** (#204) — Removed mistakenly committed `.claude/settings.local.json`; file remains in `.gitignore`.
 
 ## [8.1.0] - 2026-01-30
 


### PR DESCRIPTION
## Summary

Backmerge release v8.2.0 to develop.

Keeps develop in sync with production.

[BOT] Generated with [Claude Code](https://claude.ai/code)