### PR TITLE
backmerge: v8.4.0 → develop

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,13 +13,12 @@ jobs:
       contents: read
       pull-requests: write
       issues: read
-      id-token: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code Review
         id: claude-review
@@ -29,6 +28,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           show_full_output: true
+          allowed_tools: "Bash,WebFetch,WebSearch,Skill,Task"
           prompt: |
             IMPORTANT: You are running in GitHub Actions on Ubuntu. GITHUB_TOKEN and GH_TOKEN are already configured in the environment. Do NOT run "security find-generic-password" or override GITHUB_TOKEN — those are macOS-only patterns from CLAUDE.md that do not apply here.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ Gemini Code to Claude Code migration complete (v8.0.0).
 - `record_sync.py` auto-initializes AgentDB on first use — failures print `[WARN]` to stderr and exit 0 (non-blocking)
 - AgentDB `init_database_if_needed` checks for `agent_synchronizations` table, not just file existence — pass `--db-path` to `init_database.py` for custom paths
 - `backmerge_workflow.py cleanup-release` only prints instructions — run `git branch -d release/vX.Y.Z && git push origin --delete release/vX.Y.Z` manually
+- `backmerge_workflow.py pr-develop` may surface a GitHub CLI error "No commits between develop and release" when `gh pr create` finds no diff — create PR `main` → `develop` instead (merge commits live on `main` after release PR merge)
+- `claude-code-review.yml` requires `allowed_tools: "Bash,WebFetch,WebSearch,Skill,Task"` and `fetch-depth: 0` — without these, Claude's tool calls are denied in CI and git diff can't reach the base branch
 - Git worktrees use a `.git` file (not directory) — use `.exists()` not `.is_dir()` when checking for git repos
 - Slash commands use Markdown format (not TOML):
   - `description` → YAML frontmatter


### PR DESCRIPTION
## Summary

Backmerge release v8.4.0 to develop.

Keeps develop in sync with production.

[BOT] Generated with [Claude Code](https://claude.ai/code)