### PR TITLE
Backmerge: release/v9.1.0 -> develop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "stharrold-templates"
-version = "9.0.0"
+version = "9.1.0"
 description = "Templates and utilities for MCP server configuration and agentic development workflows"
 requires-python = ">=3.12"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -1003,7 +1003,7 @@ wheels = [
 
 [[package]]
 name = "stharrold-templates"
-version = "9.0.0"
+version = "9.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Backmerge of the v9.1.0 version bump (pyproject + uv.lock) into develop. Part of #241 (release-pilot validation). Autonomous step below the promotion gate.