### PR TITLE
docs(#243): reframe docs around three-tier model

### DIFF
--- a/.claude/skills/workflow-utilities/CLAUDE.md
+++ b/.claude/skills/workflow-utilities/CLAUDE.md
@@ -1,10 +1,9 @@
 # workflow-utilities (tactical notes)
 
 Shared utility scripts used by all other workflow skills: VCS wrapper
-(`gh`/`az`), TODO archiver, directory structure creator, skill
-scaffolder, SPDX/ASCII pre-commit hooks, and version validator. See
-[`SKILL.md`](SKILL.md) for the canonical skill definition and
-per-script reference.
+(`gh`/`az`), directory structure creator, skill scaffolder, SPDX/ASCII
+pre-commit hooks, and version validator. See [`SKILL.md`](SKILL.md) for
+the canonical skill definition and per-script reference.
 
 This file holds only gotchas that cost someone >30 minutes to
 rediscover.
@@ -28,19 +27,6 @@ rediscover.
   fallback parameter was added in v8.7.0 to deduplicate three copies
   of the same detection logic scattered across workflow scripts.
   Always pass a fallback for robustness.
-
-### TODO archiver (`workflow_archiver.py`)
-
-- **Archive destination is `ARCHIVED/` in the main repo**, not the
-  worktree. TODO files survive worktree deletion and are the audit
-  trail for completed work.
-- **Filename format**: `ARCHIVED/<original-TODO-name>-<timestamp>.md`
-  where `<timestamp>` is the archive time, not the original creation
-  time. Deliberate -- you want to know when a TODO was closed, not
-  just when it was opened.
-- **Not idempotent on same-second re-archive.** If you archive the
-  same TODO twice in one second you'll get a name collision.
-  Doesn't actually happen in practice.
 
 ### Directory structure (`directory_structure.py`)
 

--- a/.claude/skills/workflow-utilities/README.md
+++ b/.claude/skills/workflow-utilities/README.md
@@ -10,219 +10,86 @@ children:
 
 # Workflow Utilities
 
-> **Shared utilities for all workflow skills - file operations, TODO management, VCS abstraction, and documentation tools**
-
-Workflow Utilities provides reusable utilities for common workflow tasks used across all skills. It includes file deprecation, directory structure creation, TODO file updates, workflow lifecycle management, VCS abstraction, and documentation maintenance tools.
-
-## Features
-
-- ✅ **File deprecation** - Archive old files (never delete directly)
-- ✅ **Directory standards** - Create compliant directory structure
-- ✅ **TODO file updates** - Atomic YAML frontmatter updates
-- ✅ **Workflow lifecycle** - Register/archive workflows in TODO.md manifest
-- ✅ **VCS abstraction** - GitHub (`gh`) and Azure DevOps (`az`) CLI wrapper functions
-- ✅ **Documentation tools** - Version validation, skill creation, doc sync
-- ✅ **Archive management** - List and extract archived files
+> **Shared utilities for all workflow skills -- VCS abstraction, file deprecation, pre-commit hooks, version validation, and skill scaffolding**
 
 ## Quick Start
 
-### Deprecate Files (Never Delete)
-
 ```bash
-# Archive old files with timestamp
-python .claude/skills/workflow-utilities/scripts/deprecate_files.py \
-  TODO_feature_*.md \
-  old-auth-flow \
-  src/old_auth.py tests/test_old_auth.py
+# Archive deprecated files
+uv run python .claude/skills/workflow-utilities/scripts/deprecate_files.py <desc> <files...>
 
-# Creates: ARCHIVED/20251103T143000Z_old-auth-flow.zip
+# List/extract archives
+uv run python .claude/skills/workflow-utilities/scripts/archive_manager.py list
+uv run python .claude/skills/workflow-utilities/scripts/archive_manager.py extract <archive>
+
+# Validate version consistency across SKILL.md files
+uv run python .claude/skills/workflow-utilities/scripts/validate_versions.py
 ```
 
-### Create Standard Directory
+## Features
 
-```bash
-# Create directory with CLAUDE.md, README.md, ARCHIVED/
-python .claude/skills/workflow-utilities/scripts/directory_structure.py \
-  planning/auth-system
-```
-
-### Update TODO Task Status
-
-```bash
-# Mark task as complete
-python .claude/skills/workflow-utilities/scripts/todo_updater.py \
-  TODO_feature_*.md \
-  impl_003 \
-  complete \
-  35  # context usage %
-```
-
-### Workflow Lifecycle Management
-
-```bash
-# Register new workflow in TODO.md manifest
-python .claude/skills/workflow-utilities/scripts/workflow_registrar.py \
-  TODO_feature_20251103T143000Z_auth.md \
-  feature \
-  auth-system \
-  --title "User Authentication System"
-
-# Archive completed workflow
-python .claude/skills/workflow-utilities/scripts/workflow_archiver.py \
-  TODO_feature_20251103T143000Z_auth.md \
-  --summary "Implemented OAuth2 authentication" \
-  --version "1.6.0"
-
-# Sync TODO.md with filesystem (recovery)
-python .claude/skills/workflow-utilities/scripts/sync_manifest.py
-```
+- **File deprecation** -- Archive old files (never delete directly)
+- **Directory standards** -- Create standard `CLAUDE.md` / `README.md` / `ARCHIVED/` structure
+- **Archive management** -- List and extract timestamped archives
+- **VCS abstraction** -- `gh`/`az` wrapper functions (shim over `release_lib.vcs`)
+- **Pre-commit hooks** -- SPDX headers, ASCII-only, skill structure validation
+- **Version validation** -- `validate_versions.py` checks all SKILL.md semver frontmatter
+- **Skill scaffolding** -- `create_skill.py` bootstraps a new skill directory
 
 ## Scripts Reference
 
 | Script | Purpose | When to Use |
 |--------|---------|-------------|
-| `deprecate_files.py` | Archive deprecated files | When replacing old implementations |
-| `directory_structure.py` | Create standard directory structure | When creating planning/, specs/ directories |
-| `todo_updater.py` | Update task status in TODO files | When marking tasks complete |
-| `archive_manager.py` | List and extract archives | When inspecting/recovering archived files |
-| `workflow_registrar.py` | Register workflow in TODO.md | Phase 1/2 (after creating TODO file) |
-| `workflow_archiver.py` | Archive workflow in TODO.md | Phase 4.4 (after PR merged) |
-| `sync_manifest.py` | Sync TODO.md with filesystem | Recovery/verification |
-| `validate_versions.py` | Validate version consistency | Before committing skill changes |
-| `create_skill.py` | Create new skill with official docs | When adding new skills (rare) |
-| `sync_skill_docs.py` | Semi-automated doc sync | After modifying a skill |
+| `deprecate_files.py` | Timestamp-archive files into `ARCHIVED/` | Replacing old implementations |
+| `directory_structure.py` | Create standard dir (`CLAUDE.md`, `README.md`, `ARCHIVED/`) | Creating `planning/`, `specs/` |
+| `archive_manager.py` | List and extract archives | Inspecting / recovering archived files |
+| `validate_versions.py` | Validate SKILL.md semver + WORKFLOW.md version | Before committing skill changes |
+| `create_skill.py` | Scaffold a new skill directory | Adding a new skill (rare) |
+| `check_spdx_headers.py` | Pre-commit: enforce Apache-2.0 SPDX headers | Run by pre-commit automatically |
+| `check_ascii_only.py` | Pre-commit: reject non-ASCII chars in `.py` files | Run by pre-commit automatically |
+| `check_skill_structure.py` | Pre-commit: require `SKILL.md`/`README.md`/`CLAUDE.md` per skill | Run by pre-commit automatically |
 
 ## VCS Layer
 
-**Wrapper functions for GitHub (`gh`) and Azure DevOps (`az`) CLIs:**
+A backward-compat shim over `release_lib.vcs` (extracted in issue #240).
+**New code should import from `release_lib.vcs` directly.**
 
 ```python
-from vcs import create_pr, get_contrib_branch
+from vcs import create_pr, get_contrib_branch, get_username
 
-branch = get_contrib_branch()  # auto-detects provider
+branch = get_contrib_branch()   # auto-detects provider (gh / az)
+username = get_username()
 
-# Create PR
 pr_url = create_pr(
     base=branch,
-    head="feature/20251103T143000Z_auth",
-    title="feat: auth system (v1.6.0)",
+    head="release/20251103T143000Z_auth",
+    title="feat: auth system",
     body="PR body",
 )
 ```
 
-**Uses:** Auto-detected VCS provider (GitHub or Azure DevOps) for all operations
-
-## Directory Standards
-
-All directories created by workflow-utilities follow standard structure:
-
-```
-directory/
-├── CLAUDE.md      # Context for Claude Code
-├── README.md      # Human-readable documentation
-└── ARCHIVED/      # Deprecated files (except if directory IS archived)
-    ├── CLAUDE.md
-    └── README.md
-```
-
-**Enforced by:** `directory_structure.py`
-
 ## Best Practices
 
 **File deprecation:**
-- ❌ Never delete files directly
-- ✅ Always use `deprecate_files.py` to archive
+- Never delete files directly
+- Use `deprecate_files.py` to archive with a timestamp
 
 **Directory creation:**
-- ❌ Don't manually create directories
-- ✅ Use `directory_structure.py` for consistency
-
-**TODO updates:**
-- ❌ Don't manually edit TODO YAML frontmatter
-- ✅ Use `todo_updater.py` for atomic updates
-
-**Workflow lifecycle:**
-- ❌ Don't manually update TODO.md manifest
-- ✅ Use `workflow_registrar.py` and `workflow_archiver.py`
+- Use `directory_structure.py` for consistency (creates required `CLAUDE.md` / `README.md` / `ARCHIVED/`)
 
 **Documentation maintenance:**
-- ❌ Don't update versions without validation
-- ✅ Use `validate_versions.py` before committing
-- ✅ Use `sync_skill_docs.py` after skill changes
+- Run `validate_versions.py` before committing skill changes
+- SKILL.md is the canonical definition; README.md is the quick-start summary
 
-**VCS operations:**
-- ✅ Use VCS wrapper functions via `from vcs import create_pr, get_contrib_branch`
+## Integration
 
-## Integration with Other Skills
+Skills that use workflow-utilities:
 
-**All skills depend on workflow-utilities:**
-
-- **bmad-planner:** Uses `directory_structure.py`
-- **speckit-author:** Uses `directory_structure.py`
-- **quality-enforcer:** Uses `validate_versions.py`
-- **git-workflow-manager:** Uses VCS abstraction (`vcs/`)
-- **initialize-repository:** Uses `directory_structure.py`, `create_skill.py` patterns
-
-## Examples
-
-### Complete Workflow Lifecycle
-
-```bash
-# Phase 1: Register workflow after BMAD planning
-python .claude/skills/workflow-utilities/scripts/workflow_registrar.py \
-  TODO_feature_20251103T143000Z_auth.md \
-  feature auth-system --title "User Authentication"
-
-# Phase 2-3: Update tasks during implementation
-python .claude/skills/workflow-utilities/scripts/todo_updater.py \
-  TODO_feature_20251103T143000Z_auth.md impl_001 complete
-
-# Phase 4.4: Archive after PR merged
-python .claude/skills/workflow-utilities/scripts/workflow_archiver.py \
-  TODO_feature_20251103T143000Z_auth.md \
-  --summary "Implemented OAuth2" --version "1.6.0"
-```
-
-### Documentation Maintenance
-
-```bash
-# Validate version consistency
-python .claude/skills/workflow-utilities/scripts/validate_versions.py --verbose
-
-# Sync documentation after skill update
-python .claude/skills/workflow-utilities/scripts/sync_skill_docs.py \
-  bmad-planner 5.2.0
-```
-
-## Constants and Rationale
-
-| Constant | Value | Rationale |
-|----------|-------|-----------|
-| ARCHIVED/ directory | All deprecated files | Preserve history, enable recovery |
-| Timestamp format | `YYYYMMDDTHHMMSSZ` | Sortable, parseable, no shell escaping |
-| TODO.md manifest | YAML frontmatter | Single source of truth, machine-readable |
-| VCS abstraction | Unified interface | Portability, maintainability |
+- **git-workflow-manager** -- VCS abstraction (`vcs/` shim)
+- **initialize-repository** -- `directory_structure.py`, `create_skill.py`
 
 ## Related Documentation
 
-- **[SKILL.md](SKILL.md)** - Complete technical documentation
-- **[CLAUDE.md](CLAUDE.md)** - Claude Code integration guide
-- **[CHANGELOG.md](CHANGELOG.md)** - Version history
-
-**See also:**
-- [WORKFLOW.md](../../WORKFLOW.md) - Complete workflow guide
-- [UPDATE_CHECKLIST.md](../../.claude/skills/UPDATE_CHECKLIST.md) - Skill update checklist
-
-## Contributing
-
-This skill is part of the workflow system. To update:
-
-1. Modify scripts in `scripts/`
-2. Update version in `SKILL.md` frontmatter
-3. Document changes in `CHANGELOG.md`
-4. Run validation: `python .claude/skills/workflow-utilities/scripts/validate_versions.py`
-5. Sync documentation: `python .claude/skills/workflow-utilities/scripts/sync_skill_docs.py workflow-utilities <version>`
-
-## License
-
-Part of the german repository workflow system.
+- **[SKILL.md](SKILL.md)** -- canonical skill definition and per-script reference
+- **[CLAUDE.md](CLAUDE.md)** -- gotchas and tactical notes
+- **[WORKFLOW.md](../../WORKFLOW.md)** -- three-tier workflow guide

--- a/.claude/skills/workflow-utilities/README.md
+++ b/.claude/skills/workflow-utilities/README.md
@@ -55,7 +55,7 @@ A backward-compat shim over `release_lib.vcs` (extracted in issue #240).
 **New code should import from `release_lib.vcs` directly.**
 
 ```python
-from vcs import create_pr, get_contrib_branch, get_username
+from release_lib.vcs import create_pr, get_contrib_branch, get_username
 
 branch = get_contrib_branch()   # auto-detects provider (gh / az)
 username = get_username()

--- a/BUNDLES.md
+++ b/BUNDLES.md
@@ -2,6 +2,17 @@
 
 Bundle manifest for `stharrold-templates`. Each bundle is a named set of files that can be applied to a target repository.
 
+## Three-tier model
+
+| Tier | Role | Bundle |
+|------|------|--------|
+| **Tier 1 — policy** | `release-pilot` skill (user-level, not bundled) + `git` bundle skills + sN slash commands | `git` |
+| **Tier 2 — library** | `release_lib` Python package (not shipped by any bundle; lives in this repo) | — |
+| **Tier 3 — CI** | GitHub Actions workflows (`tests.yml`, `claude-code-review.yml`, `secrets-example.yml`) | `ci` |
+
+`release-pilot` (`~/.claude/skills/release-pilot/`) is installed at the user level and is **not shipped by any bundle** — it is the policy/playbook layer that calls into `release_lib` (Tier 2) and drives the `git`-bundle skills (Tier 1).
+
+
 ## Usage
 
 ### Quick Start
@@ -49,11 +60,10 @@ python .tmp/stharrold-templates/scripts/apply_bundle.py .tmp/stharrold-templates
 
 ### `git` -- Git Workflow and Branch Management
 
-Skills, commands, and documentation for the `main <- develop <- contrib/* <- feature/*` branch workflow.
+Skills, commands, and documentation for the `main <- develop <- contrib/<user> <- release/<ts>_<slug>` branch workflow.
 
 **Skills (template-owned):**
 - `.claude/skills/git-workflow-manager/`
-- `.claude/skills/workflow-orchestrator/`
 - `.claude/skills/workflow-utilities/`
 
 **Commands (template-owned):**
@@ -307,29 +317,11 @@ Ship a conservative `_headers` file for Cloudflare Pages with baseline CSP, HSTS
 
 ---
 
-### `agentdb` -- Opt-in DuckDB workflow state tracking
-
-**NEW in v8.9**: broken out of the `full` bundle.
-
-AgentDB provides persistent state tracking for workflow transitions via a local DuckDB. Each invocation of `/workflow:s1-worktree` .. `/workflow:s4-backmerge` records its completion, enabling analytics queries over historical workflow state (which step a branch is in, how long phases took, cross-team dependency graphs).
-
-**This is opt-in.** Git branches and PR state are the authoritative source of workflow state for new projects. The downstream reference implementation (synavistra) explicitly removed AgentDB tracking and records the decision in its own CLAUDE.md. The `agentdb` bundle is kept for teams whose release processes benefit from the analytics layer -- it is NOT required for the `git` / `s1..s4` workflow to function.
-
-**Skill (template-owned):**
-- `.claude/skills/agentdb-state-manager/`
-
-**Merge files (user-owned):**
-- `pyproject.toml` -- adds `duckdb>=1.2.0` to `[dependency-groups] dev`
-
-**Schema stability**: the internal phase keys (`phase_v7x1_1_worktree` .. `phase_v7x1_4_backmerge`) are deliberately NOT renamed to match the sN slash-command names. They are stable dict keys in `PHASE_MAP` and row values in `agent_synchronizations`, kept for backward compatibility with existing AgentDB databases.
-
----
-
-### `full` -- Everything (except agentdb)
+### `full` -- Everything (except security-headers)
 
 All files from `git` + `secrets` + `ci` + `graphrag` (which includes `pipeline`) + `sql-pipeline` + `data-catalog`, plus additional skills and documentation.
 
-**Note (v8.9 breaking change)**: `agentdb-state-manager` is no longer bundled with `full`. Teams that want AgentDB tracking must apply `--bundle agentdb` explicitly. This was changed because the downstream reference (synavistra) removed AgentDB and the skill added ~200 lines of context load that most users don't need.
+**Note**: `security-headers` is **not** included in `full`. Its `_headers` file is user-owned (skip-on-update) and is intentionally kept separate so downstream customizations survive re-apply. Apply `--bundle security-headers` explicitly when needed.
 
 **Additional skills (template-owned):**
 - `.claude/skills/tech-stack-adapter/`
@@ -367,9 +359,9 @@ Traceability for the conventions shipped by these bundles. Each entry links back
 
 - **`v7x1_N` slash command prefixes renamed to `sN`** (step-N). `v7x1` was a historical workflow version identifier with no meaning for new users; `sN` reads as "step N" and matches the existing "Step X of 4" prose in the command descriptions.
 
-### AgentDB decision (v8.9)
+### AgentDB decision (removed in v9.1.0)
 
-- **`agentdb-state-manager` moved from `full` to its own opt-in `agentdb` bundle.** Synavistra's auto-memory records the decision: *"No AgentDB: DuckDB state tracking removed; git branches are the state."* The skill still works and is kept for teams that want analytics queries, but new projects are no longer opted-in by default.
+- **`agentdb-state-manager` skill deleted in #242.** Synavistra's auto-memory records the decision: *"No AgentDB: DuckDB state tracking removed; git branches are the state."* The skill was moved to opt-in in v8.9 and then deleted entirely in v9.1.0. Git branches + the GitHub PR/checks API are the authoritative source of workflow state.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ deleting stale entries over adding caveats.
   (synavistra) proved the stubs were actively harmful.
 - Architecture descriptions, stack diagrams, bundle maps.
   → [`BUNDLES.md`](BUNDLES.md) for bundle contents and file ownership.
-  → [`WORKFLOW.md`](WORKFLOW.md) for the v7x1/sN workflow guide.
+  → [`WORKFLOW.md`](WORKFLOW.md) for the three-tier model and workflow guide.
 - Transient state, release notes, commit logs → git history,
   [`CHANGELOG.md`](CHANGELOG.md), GitHub issues.
 - Per-skill reference docs → each skill's `SKILL.md` is the canonical
@@ -50,9 +50,9 @@ the rest.
 
 ## Branch structure
 
-`main` <- `develop` <- `contrib/stharrold` <- `feature/*`
+`main` <- `develop` <- `contrib/<user>` <- `release/<ts>_<slug>` (worktree)
 
-Always end sessions on `contrib/stharrold`.
+Always end sessions on `contrib/<user>` (e.g. `contrib/stharrold`).
 
 ## Commands
 
@@ -102,8 +102,6 @@ uv run python .claude/skills/.../scripts/*.py  # Run skill scripts
   - `!{cmd}` → `` !`cmd` ``
   - `{{args}}` → `$ARGUMENTS`
 - **Workflow slash-command prefixes were renamed in v8.9**: `v7x1_1-worktree` → `s1-worktree`, `v7x1_2-integrate` → `s2-integrate`, `v7x1_3-release` → `s3-release`, `v7x1_4-backmerge` → `s4-backmerge`. The `sN` prefix ("step N") is shorter and more descriptive.
-- **`record_sync.py` (AgentDB state manager) auto-initializes the database on first use.** Failures print `[WARN]` to stderr and exit 0 (non-blocking by design).
-- **AgentDB `init_database_if_needed` checks for the `agent_synchronizations` table**, not just file existence. Pass `--db-path` to `init_database.py` for custom paths.
 - **After deleting or renaming Python modules under `.claude/skills/`**, grep all `*.md` files under the skills directory for stale references (CLAUDE.md, README.md, SKILL.md frontmatter all show up in the grep).
 
 ---
@@ -114,7 +112,7 @@ This repo provides installable workflow bundles. See [BUNDLES.md](BUNDLES.md)
 for the authoritative catalog and file-ownership rules.
 
 Current bundles: `git`, `secrets`, `ci`, `pipeline`, `sql-pipeline`,
-`graphrag`, `data-catalog`, `full`.
+`graphrag`, `data-catalog`, `security-headers`, `full`.
 
 CLI:
 
@@ -129,4 +127,4 @@ python scripts/apply_bundle.py <source-repo> <target-repo> \
 - **`../library/`** is the reference implementation for secrets management patterns.
 - **`../synavistra/`** is the reference implementation for `claude-code-review.yml` and has proven several CLAUDE.md conventions used here.
 - **`scripts/secrets_run.py`** runs commands with secrets from the OS keyring (#169).
-- **AgentDB state manager** (`.claude/skills/agentdb-state-manager/`) has test coverage in `tests/skills/`. Kept as opt-in; no longer included in the `full` bundle as of v8.9.
+- **`release_lib/`** is the Tier-2 deterministic library (`semver.py`, `vcs/`, `bundles.py`). Not shipped by any bundle — it is the engine that the `git` bundle's skills and the `release-pilot` user skill call into.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,13 +147,14 @@ gh pr create \
 
 ### Workflow Tools
 
-This repository includes 6 active workflow skills in `.claude/skills/`:
-- `workflow-orchestrator`: Main coordinator.
-- `git-workflow-manager`: Git automation.
-- `tech-stack-adapter`: Stack detection.
-- `workflow-utilities`: Shared utilities.
-- `agentdb-state-manager`: State tracking.
-- `initialize-repository`: Repository bootstrapping.
+This repository includes 5 active workflow skills in `.claude/skills/`:
+- `git-workflow-manager`: Git automation (worktrees, PRs, semantic versioning).
+- `tech-stack-adapter`: Stack detection (`TEST_CMD`/`BUILD_CMD` emission).
+- `workflow-utilities`: Shared utilities (VCS wrapper, pre-commit hooks, version validator).
+- `claude-md-hygiene`: Enforces the "earn it" CLAUDE.md discipline.
+- `initialize-repository`: Meta-skill to bootstrap new repos with the full workflow system.
+
+The `release-pilot` policy skill lives at `~/.claude/skills/release-pilot/` (user-level, not bundled).
 
 ## AI Configuration Guidelines
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,23 @@
 
 Templates and utilities for MCP (Model Context Protocol) server configuration and agentic development workflows.
 
+## Three-tier model
+
+| Tier | What | Where |
+|------|------|--------|
+| **Tier 1 — policy** | `release-pilot` skill (declarative playbook: gates, topology, autonomy contract) | `~/.claude/skills/release-pilot/` (user-level, not bundled) |
+| **Tier 2 — library** | `release_lib` Python package (deterministic helpers: semver, VCS, bundle engine) | `release_lib/` in this repo |
+| **Tier 3 — CI** | GitHub Actions workflows (tests, Claude code-review) | `.github/workflows/` (shipped via `ci` bundle) |
+
+The `git` bundle ships Tier-1 **skills** (`git-workflow-manager`, `workflow-utilities`) and the sN slash commands. The `ci` bundle ships Tier-3 CI artifacts. `release-pilot` is installed separately at the user level.
+
 ## Features
 
-- **sN workflow** - Streamlined 4-step autonomous development process
+- **release-pilot skill** - User-level declarative playbook driving the full release cycle
+- **release_lib** - Deterministic Python helpers: `semver.py` (auto-bump), `vcs/` (gh/az), `bundles.py` (bundle engine)
 - **Claude Code Review** - Automated PR analysis via GitHub Actions
-- **AgentDB Tracking** - Persistent state and metrics using DuckDB
+- **Installable bundles** - `git`, `secrets`, `ci`, `pipeline`, `sql-pipeline`, `graphrag`, `data-catalog`, `security-headers`, `full`
 - **Containerized development** - Podman + uv + Python 3.12 for consistency
-- **AI-optimized documentation** - Modular guides (≤30KB per file) for context efficiency
-- **AI-agent native** - Optimized for Claude Code and MCP (Model Context Protocol)
 
 ## Prerequisites
 
@@ -76,13 +85,14 @@ Replace `--bundle git` with whichever bundles you need:
 
 | Bundle | What you get |
 |--------|-------------|
-| `git` | Branch workflow, slash commands, skills |
+| `git` | Branch workflow, slash commands, skills (Tier 1) |
 | `secrets` | Keyring-backed secrets management |
-| `ci` | GitHub Actions, containers, pre-commit |
+| `ci` | GitHub Actions, containers, pre-commit (Tier 3) |
 | `pipeline` | 6-stage document processing ETL |
 | `sql-pipeline` | SQL Server ETL with pyodbc, retry, resumption |
 | `graphrag` | Graph RAG retrieval (includes `pipeline`) |
-| `full` | Everything above + extra skills and docs |
+| `security-headers` | Cloudflare Pages baseline CSP / HSTS headers (not in `full`) |
+| `full` | All of the above except `security-headers` + extra skills/docs |
 
 **Or run manually:**
 
@@ -176,7 +186,7 @@ See `secrets.toml` for secret definitions.
 │   ├── guides/             # Production guides
 │   ├── research/           # Exploratory documents
 │   └── reference/          # Reference materials
-├── .claude/skills/         # AI workflow skills (6 active)
+├── .claude/skills/         # AI workflow skills (5 active)
 ├── scripts/                # Utility scripts (secrets, run helpers)
 └── ARCHIVED/               # Archived specs, planning docs, deprecated code
 ```

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,15 +1,19 @@
-# Workflow Guide - sN (Implementation)
+# Workflow Guide
 
-**Version:** 7.0.0
-**Date:** 2026-01-01
-**Architecture:** 4-phase workflow using Claude Code
+**Version:** 9.1.1
 
-## Overview
+## Three-tier model
 
-This repository uses a streamlined 4-phase workflow for Python development:
-- **Git-flow hybrid** with worktrees for isolation
-- **Claude Code** for planning, architecture, and implementation
-- **No separate manual quality gates** (Claude Code Review automated via GitHub Actions)
+| Tier | Role | Location |
+|------|------|----------|
+| **Tier 1 — policy** | `release-pilot` skill: declarative playbook (gates, topology, autonomy contract) | `~/.claude/skills/release-pilot/` (user-level) |
+| **Tier 2 — library** | `release_lib`: deterministic Python helpers (`semver.py`, `vcs/`, `bundles.py`) | `release_lib/` in this repo |
+| **Tier 3 — CI** | GitHub Actions: `tests.yml`, `claude-code-review.yml`, `secrets-example.yml` | `.github/workflows/` (shipped via `ci` bundle) |
+
+**The product is the three tiers**, not the sN slash commands. The sN commands
+(`/workflow:s1-worktree` .. `/workflow:s4-backmerge`) are low-level helpers shipped
+by the `git` bundle; `release-pilot` drives them as needed. For a full release cycle,
+invoke `release-pilot` via the `Skill` tool.
 
 ## Prerequisites
 
@@ -22,170 +26,156 @@ Required tools:
 
 Verify prerequisites:
 ```bash
-# GitHub CLI:
 gh auth status          # Must be authenticated
-
 uv --version            # Must be installed
 python3 --version       # Must be 3.11+
 ```
 
-## Phase 0: Bootstrapping a New Repository
-
-This repository provides a meta-skill to bootstrap other projects with this workflow system.
-
-### From This Repository
-```bash
-python .claude/skills/initialize-repository/scripts/initialize_repository.py . /path/to/new-repo
-```
-
-### From a Cloned Release
-If you have cloned `stharrold-templates` into a subdirectory (e.g., `.tmp/`):
-```bash
-python .tmp/stharrold-templates/.claude/skills/initialize-repository/scripts/apply_workflow.py .tmp/stharrold-templates .
-```
-
-## sN workflow
+## Branch topology
 
 ```
-/workflow:s1-worktree "feature description"
-    | creates worktree, user implements feature in worktree
-    v
-/workflow:s2-integrate "feature/YYYYMMDDTHHMMSSZ_slug"
-    | PR feature->contrib->develop
-    v
-/workflow:s3-release
-    | create release, PR to main, tag
-    v
-/workflow:s4-backmerge
-    | PR release->develop, rebase contrib, manual cleanup
+release/<YYYYMMDDTHHMMSSZ>_<slug>   <- work branch (worktree)
+   |  PR + gate-merge (autonomous; release-pilot drives this)
+   v
+contrib/<user>                       <- personal integration (e.g. contrib/stharrold)
+   |  rebase onto develop, PR + gate-merge (autonomous)
+   v
+develop
+   |  ===== EXPLICIT HUMAN CONFIRM REQUIRED =====
+   v
+release/vN.N.N                      <- version branch (cut from develop)
+   |  PR to main; confirm-gated
+   v
+main  (tag vN.N.N)
+   |  backmerge release/vN.N.N -> develop (autonomous)
+   v
+develop  ->  rebase contrib/<user> onto develop
+```
+
+Work branches (`release/<ts>_<slug>`) replace the old `feature/*` naming.
+Two distinct `release/*` namespaces: timestamped work branches vs. versioned
+promotion branches (`release/vN.N.N`).
+
+### Branch protection
+
+**Protected (PR-only):** `main`, `develop`
+
+**Editable:** `contrib/*`, `release/<ts>_<slug>`
+
+**Ephemeral:** `release/vN.N.N` — deleted after backmerge completes.
+
+## Gates (decided contract)
+
+| Gate | Type | Behavior |
+|------|------|----------|
+| Human reviews | soft, 10-min ceiling | Poll `gh pr view --json reviews`. Merge on timeout if CI is green. |
+| CI checks | hard | `gh pr checks` must be green before any merge. Auto-fix on failure. |
+| `develop -> release -> main` | confirm | Stop; require explicit human confirmation before creating `release/vN.N.N` or tagging. |
+
+## Starting a release
+
+Invoke via Skill tool:
+
+```
+Skill("release-pilot")
+```
+
+`release-pilot` reads git state, determines current phase, and drives forward.
+For the specific steps it executes see `~/.claude/skills/release-pilot/SKILL.md`.
+
+## sN slash commands (low-level)
+
+The sN commands are building blocks used by `release-pilot`; you can also invoke them directly:
+
+```
+/workflow:s1-worktree "feature description"   # Create worktree on release/<ts>_<slug>
+/workflow:s2-integrate "release/<ts>_<slug>"  # PR work->contrib->develop
+/workflow:s3-release                          # Cut release/vN.N.N, PR->main, tag
+/workflow:s4-backmerge                        # PR release/vN.N.N->develop, cleanup
 ```
 
 ### Step 1: Create Worktree (`/workflow:s1-worktree`)
 
-Creates isolated git worktree for feature development.
+Creates an isolated git worktree on a `release/<ts>_<slug>` branch from `contrib/<user>`.
 
 ```bash
 /workflow:s1-worktree "add user authentication"
 ```
 
-**Output:**
-- Branch: `feature/{timestamp}_{slug}`
-- Worktree: `../{project}_feature_{timestamp}_{slug}/`
+**Output:** Branch `release/<timestamp>_<slug>`, worktree at `../<project>_release_<timestamp>_<slug>/`
 
-**Next steps displayed:** Navigate to worktree and implement the feature.
+### Step 2: Integrate (`/workflow:s2-integrate`)
 
-### Step 2: Feature Implementation
-
-Run in the feature worktree (not main repo) using Claude Code:
+From the main repo after implementation is complete:
 
 ```bash
-cd <worktree-path>
-# Then just chat with Claude Code:
-"Implement user authentication with JWT tokens"
-```
-
-**Claude Code handles:**
-- Understanding the codebase
-- Planning the implementation
-- Writing code and tests
-- Refinement
-
-No separate planning documents needed.
-
-### Step 3: Integrate (`/workflow:s2-integrate`)
-
-From main repo, after implementation is complete:
-
-```bash
-/workflow:s2-integrate "feature/20251229T120000Z_add-user-auth"
+/workflow:s2-integrate "release/20251229T120000Z_add-user-auth"
 ```
 
 **Two modes:**
-- **Full mode** (with branch arg): PR feature->contrib, manual worktree cleanup, manual branch cleanup, PR contrib->develop
+- **Full mode** (with branch arg): PR work->contrib, worktree cleanup, PR contrib->develop
 - **Contrib-only mode** (no arg): PR contrib->develop only
 
-**Manual gates:** PRs require approval in GitHub UI.
-
-### Step 4: Release (`/workflow:s3-release`)
-
-Creates release from develop:
+### Step 3: Release (`/workflow:s3-release`)
 
 ```bash
-/workflow:s3-release           # Auto-calculate version
-/workflow:s3-release v1.2.0    # Explicit version
+/workflow:s3-release           # auto-calculate version via release_lib.semver
+/workflow:s3-release v1.2.0    # explicit version
 ```
 
-**Creates:**
-- Branch: `release/{version}` from develop
-- PR to main (requires approval)
-- Tag on main after merge
+Creates `release/vN.N.N` from develop, PRs to main, tags on merge.
 
-### Step 5: Backmerge (`/workflow:s4-backmerge`)
-
-Syncs release changes back:
+### Step 4: Backmerge (`/workflow:s4-backmerge`)
 
 ```bash
 /workflow:s4-backmerge
 ```
 
-**Actions:**
-- PR release->develop (requires approval)
-- Rebases contrib on develop
-- Instructs manual deletion of release branch
+PRs `release/vN.N.N -> develop`, rebases `contrib/<user>` onto develop, deletes the release branch.
 
-## Branch Structure
+## Bootstrapping a new repository
 
-```
-main                           <- Production (tagged vX.Y.Z)
-  ^
-release/vX.Y.Z                <- Release candidate (ephemeral)
-  ^
-develop                        <- Integration branch
-  ^
-contrib/<gh-user>             <- Personal contribution (contrib/stharrold)
-  ^
-feature/<timestamp>_<slug>    <- Isolated feature (worktree)
+Apply the `git` bundle (Tier 1 skills + sN commands + `WORKFLOW.md` + `CONTRIBUTING.md`):
+
+```bash
+cd /path/to/new-repo
+git clone https://github.com/stharrold/stharrold-templates.git .tmp/stharrold-templates
+uv run python .tmp/stharrold-templates/scripts/apply_bundle.py .tmp/stharrold-templates . --bundle git
+rm -rf .tmp/stharrold-templates
 ```
 
-### Branch Protection
+For the full workflow system (all tiers):
 
-**Protected branches (PR-only):**
-- `main` - Production
-- `develop` - Integration
+```bash
+# Tier 1+3: apply git + ci bundles
+cd /path/to/new-repo
+git clone https://github.com/stharrold/stharrold-templates.git .tmp/stharrold-templates
+uv run python .tmp/stharrold-templates/scripts/apply_bundle.py .tmp/stharrold-templates . --bundle git --bundle ci
+rm -rf .tmp/stharrold-templates
 
-**Editable branches:**
-- `contrib/*` - Personal contribution
-- `feature/*` - Feature development
+# Tier 1 policy skill: install release-pilot separately (user-level)
+# Copy ~/.claude/skills/release-pilot/ from a working instance or craft from SKILL.md.
+```
 
-**Ephemeral branches:**
-- `release/*` - Created in `/workflow:s3-release`, manually deleted after `/workflow:s4-backmerge`
+Or use `initialize-repository` to interactively scaffold a complete project:
 
-## Key Differences from v1-v7
+```bash
+uv run python .claude/skills/initialize-repository/scripts/initialize_repository.py . /path/to/new-repo
+```
 
-| Aspect | v1-v7 | sN |
-|--------|-------|-----|
-| Planning | BMAD documents + SpecKit specs | Built-in Claude Code tools |
-| Quality gates | 5 separate gates | Claude Code Review |
-| Steps | 7 phases | 4 steps |
-| Artifacts | requirements.md, architecture.md, spec.md, plan.md | None (Claude Code handles internally) |
+## Skills
 
-## Skills System
+| Skill | Bundle | Purpose |
+|-------|--------|---------|
+| `release-pilot` | user-level (not bundled) | Declarative release playbook; drives the full cycle |
+| `git-workflow-manager` | `git` | Worktrees, PR operations, semantic versioning helpers |
+| `workflow-utilities` | `git` | VCS wrapper (`gh`/`az`), pre-commit hooks, version validator |
+| `tech-stack-adapter` | `full` | Python/uv stack detection, `TEST_CMD`/`BUILD_CMD` emission |
+| `claude-md-hygiene` | not bundled (in-repo only) | Enforces the "earn it" CLAUDE.md discipline |
+| `initialize-repository` | `full` | Meta-skill: bootstraps a new repo with the full workflow system |
 
-| Skill | Purpose |
-|-------|---------|
-| workflow-orchestrator | Main coordinator, templates |
-| git-workflow-manager | Worktrees, PRs, semantic versioning |
-| tech-stack-adapter | Python/uv detection |
-| workflow-utilities | Archive, directory structure |
-| agentdb-state-manager | Workflow state tracking |
-| initialize-repository | Bootstrap new repos |
+## Related documentation
 
-**Archived skills** (see `ARCHIVED/`):
-- bmad-planner
-- speckit-author
-- quality-enforcer
-
-## Related Documentation
-
-- **[CLAUDE.md](CLAUDE.md)** - Main AI context file
+- **[CLAUDE.md](CLAUDE.md)** - Gotchas and key context for Claude Code sessions
+- **[BUNDLES.md](BUNDLES.md)** - Bundle catalog and file ownership rules
 - **[CHANGELOG.md](CHANGELOG.md)** - Version history


### PR DESCRIPTION
Integrates PR #251 into develop.

Reframes BUNDLES.md / WORKFLOW.md / README.md / CLAUDE.md / CONTRIBUTING.md around the three-tier model:
- Tier 1: `release-pilot` skill (user-level policy) + `git` bundle skills + sN commands
- Tier 2: `release_lib` (deterministic Python library)
- Tier 3: CI artifacts (shipped by `ci` bundle)

Removes all stale `agentdb-state-manager` and `workflow-orchestrator` references from user-facing docs. Rewrites `workflow-utilities/README.md` to reflect actual scripts.

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)