### PR TITLE
feat(user-skills): track user-level skills and add install_user_skills.py

### DIFF
--- a/BUNDLES.md
+++ b/BUNDLES.md
@@ -10,7 +10,7 @@ Bundle manifest for `stharrold-templates`. Each bundle is a named set of files t
 | **Tier 2 — library** | `release_lib` Python package (not shipped by any bundle; lives in this repo) | — |
 | **Tier 3 — CI** | GitHub Actions workflows (`tests.yml`, `claude-code-review.yml`, `secrets-example.yml`) | `ci` |
 
-`release-pilot` (`~/.claude/skills/release-pilot/`) is installed at the user level and is **not shipped by any bundle** — it is the policy/playbook layer that calls into `release_lib` (Tier 2) and drives the `git`-bundle skills (Tier 1).
+`release-pilot` (`~/.claude/skills/release-pilot/`) and other user-level skills live in `user-skills/` in this repo. Install them with `install_user_skills.py` — they are **not shipped by `apply_bundle.py`** because they target `~/.claude/skills/`, not a project repo.
 
 
 ## Usage
@@ -314,6 +314,41 @@ Ship a conservative `_headers` file for Cloudflare Pages with baseline CSP, HSTS
 **Do not use when:**
 - Your app runs on a non-Cloudflare platform that ignores `_headers`.
 - You have an existing carefully-tuned CSP that the template baseline would regress.
+
+---
+
+### User Skills
+
+User-level skills live in `user-skills/` and are installed to `~/.claude/skills/` (not a project repo). Use `scripts/install_user_skills.py`:
+
+```bash
+# Clone templates next to your repo (or into .tmp/)
+git clone https://github.com/stharrold/stharrold-templates.git .tmp/stharrold-templates
+
+# Workflow skills -- release-pilot, branch-release.md, branch-start.md, pr-ship.md
+python .tmp/stharrold-templates/scripts/install_user_skills.py .tmp/stharrold-templates --bundle workflow
+
+# Research skills -- scholar-labs-search (for repos that do literature search)
+python .tmp/stharrold-templates/scripts/install_user_skills.py .tmp/stharrold-templates --bundle research
+
+# All user skills
+python .tmp/stharrold-templates/scripts/install_user_skills.py .tmp/stharrold-templates --bundle all
+
+# Dry run first
+python .tmp/stharrold-templates/scripts/install_user_skills.py .tmp/stharrold-templates --bundle workflow --dry-run
+
+# Force overwrite existing skills (picks up upstream changes)
+python .tmp/stharrold-templates/scripts/install_user_skills.py .tmp/stharrold-templates --bundle workflow --force
+```
+
+**Bundles:**
+
+| Bundle | Skills installed |
+|--------|-----------------|
+| `workflow` | `release-pilot/` (SKILL.md), `branch-release.md`, `branch-start.md`, `pr-ship.md` |
+| `research` | `scholar-labs-search/` (SKILL.md + scripts/) |
+
+**Ownership:** Skip-on-update by default (local edits survive reinstall). `--force` to pull upstream changes.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,23 @@ rm -rf .tmp/stharrold-templates
 
 See [BUNDLES.md](BUNDLES.md) for bundle contents, file ownership, and update behavior.
 
+### Step 3: Install user-level skills (optional)
+
+User skills (`release-pilot`, `scholar-labs-search`, etc.) install to `~/.claude/skills/` on your machine -- not into any specific repo. Install once per machine, then they are available everywhere:
+
+```bash
+# Workflow skills (release-pilot, branch-release, branch-start, pr-ship):
+python .tmp/stharrold-templates/scripts/install_user_skills.py .tmp/stharrold-templates --bundle workflow
+
+# Research skills (scholar-labs-search) -- for repos that use academic literature search:
+python .tmp/stharrold-templates/scripts/install_user_skills.py .tmp/stharrold-templates --bundle research
+
+# Dry run to preview:
+python .tmp/stharrold-templates/scripts/install_user_skills.py .tmp/stharrold-templates --bundle workflow --dry-run
+```
+
+Existing local skills are skipped by default; use `--force` to pull upstream changes.
+
 ## Secrets Management
 
 Cross-platform secrets management using environment variables with keyring fallback.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -147,14 +147,14 @@ rm -rf .tmp/stharrold-templates
 For the full workflow system (all tiers):
 
 ```bash
-# Tier 1+3: apply git + ci bundles
+# Tier 1+3: apply git + ci bundles, then install user-level skills
 cd /path/to/new-repo
 git clone https://github.com/stharrold/stharrold-templates.git .tmp/stharrold-templates
 uv run python .tmp/stharrold-templates/scripts/apply_bundle.py .tmp/stharrold-templates . --bundle git --bundle ci
-rm -rf .tmp/stharrold-templates
 
-# Tier 1 policy skill: install release-pilot separately (user-level)
-# Copy ~/.claude/skills/release-pilot/ from a working instance or craft from SKILL.md.
+# Tier 1 policy skill: install release-pilot (user-level, installs to ~/.claude/skills/)
+python .tmp/stharrold-templates/scripts/install_user_skills.py .tmp/stharrold-templates --bundle workflow
+rm -rf .tmp/stharrold-templates
 ```
 
 Or use `initialize-repository` to interactively scaffold a complete project:

--- a/scripts/install_user_skills.py
+++ b/scripts/install_user_skills.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 stharrold
+# SPDX-License-Identifier: Apache-2.0
+"""
+Install user-level Claude Code skills from stharrold-templates into ~/.claude/skills/.
+
+Skills are copied from user-skills/<bundle>/ to --target (default: ~/.claude/skills/).
+Existing files are skipped by default; use --force to overwrite.
+
+Usage:
+    python scripts/install_user_skills.py <source_repo> [--bundle workflow] [--bundle research]
+    python scripts/install_user_skills.py <source_repo> --bundle all
+    python scripts/install_user_skills.py <source_repo> --bundle workflow --force
+    python scripts/install_user_skills.py <source_repo> --dry-run
+
+Bundles:
+    workflow  -- release-pilot, branch-release.md, branch-start.md, pr-ship.md
+    research  -- scholar-labs-search
+    all       -- all of the above
+"""
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+BUNDLES = {
+    "workflow": [
+        "release-pilot",
+        "branch-release.md",
+        "branch-start.md",
+        "pr-ship.md",
+    ],
+    "research": [
+        "scholar-labs-search",
+    ],
+}
+
+
+def _resolve_bundles(requested):
+    if "all" in requested:
+        return list(BUNDLES.keys())
+    unknown = set(requested) - set(BUNDLES)
+    if unknown:
+        print(f"ERROR: unknown bundle(s): {', '.join(sorted(unknown))}", file=sys.stderr)
+        print(f"Available: {', '.join(BUNDLES)}, all", file=sys.stderr)
+        sys.exit(1)
+    return list(requested)
+
+
+def _copy_entry(src, dst, force, dry_run, *, label):
+    """Copy a file or directory tree from src to dst, respecting skip-on-update."""
+    if dst.exists() and not force:
+        print(f"  skip   {label}  (exists; use --force to overwrite)")
+        return
+    action = "dry-run" if dry_run else ("overwrite" if dst.exists() else "install")
+    print(f"  {action:<9} {label}")
+    if dry_run:
+        return
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if src.is_dir():
+        if dst.exists():
+            shutil.rmtree(dst)
+        shutil.copytree(src, dst)
+    else:
+        shutil.copy2(src, dst)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("source_repo", type=Path, help="path to the stharrold-templates repo")
+    ap.add_argument("--bundle", action="append", default=[], metavar="NAME", help="bundle to install (workflow, research, all); repeatable")
+    ap.add_argument("--target", type=Path, default=Path.home() / ".claude" / "skills", help="destination directory (default: ~/.claude/skills/)")
+    ap.add_argument("--force", action="store_true", help="overwrite existing files")
+    ap.add_argument("--dry-run", action="store_true", help="show what would happen without writing")
+    args = ap.parse_args()
+
+    if not args.bundle:
+        ap.print_help()
+        print("\nERROR: at least one --bundle is required.", file=sys.stderr)
+        sys.exit(1)
+
+    bundles = _resolve_bundles(args.bundle)
+    user_skills_root = args.source_repo / "user-skills"
+
+    if not user_skills_root.is_dir():
+        print(f"ERROR: {user_skills_root} not found. Is source_repo correct?", file=sys.stderr)
+        sys.exit(1)
+
+    args.target.mkdir(parents=True, exist_ok=True)
+
+    print(f"Installing user skills -> {args.target}")
+    if args.force:
+        print("  (--force: existing files will be overwritten)")
+    if args.dry_run:
+        print("  (--dry-run: no files will be written)")
+    print()
+
+    for bundle_name in bundles:
+        bundle_dir = user_skills_root / bundle_name
+        print(f"[{bundle_name}]")
+        for entry_name in BUNDLES[bundle_name]:
+            src = bundle_dir / entry_name
+            dst = args.target / entry_name
+            if not src.exists():
+                print(f"  ERROR: source missing: {src}", file=sys.stderr)
+                sys.exit(1)
+            _copy_entry(src, dst, args.force, args.dry_run, label=entry_name)
+        print()
+
+    if args.dry_run:
+        print("Dry run complete. Rerun without --dry-run to apply.")
+    else:
+        print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/user-skills/research/scholar-labs-search/SKILL.md
+++ b/user-skills/research/scholar-labs-search/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: scholar-labs-search
+description: >-
+  Run academic literature searches on Google Scholar Labs through the user's
+  own authenticated Chrome, then extract the papers and citations found. Use
+  this whenever the user wants to search Google Scholar, find peer-reviewed
+  sources or citations for a claim, answer a research question with the
+  literature, or gather academic evidence, even if they don't name "Scholar
+  Labs" explicitly. Especially important because Scholar Labs has a strict
+  ~3-queries-per-day quota: this skill prevents wasting queries on malformed
+  searches and on re-reads that cost nothing. Do NOT use for general web
+  search, fetching one known URL, or reading a PDF the user already has.
+compatibility: Requires the playwright Python package and a Chromium-based browser the user can authenticate.
+---
+
+# Google Scholar Labs search
+
+Scholar Labs is Google's experimental AI-overview search over scholarly papers. It
+evaluates ~60-200 results per query and surfaces ~10 with structured summaries, which
+makes it excellent for finding peer-reviewed evidence quickly. Two constraints shape how
+to use it well:
+
+1. **It is quota-limited** (commonly ~3 queries/day per Google account). A wasted query is
+   expensive. Treat every search as scarce.
+2. **Authentication is the user's job.** Scholar Labs needs a logged-in Google session, and
+   automating Google login is fragile and against the spirit of the user-attended workflow.
+   So the human launches and authenticates the browser; this skill drives it afterward.
+
+Because of (1), the golden rule is: **never burn a query you didn't have to.** Re-reads are
+free (`--read-only`); only a fresh `--query` costs quota.
+
+## Step 1 - Decide whether Scholar Labs is even the right tool
+
+Reserve the scarce quota for questions that genuinely need *peer-reviewed* citations
+(empirical claims, healthcare/clinical evidence, "what does the literature show about X").
+For general definitions, vendor docs, news, or background, prefer ordinary web search or a
+deep-research tool and save the quota. Tell the user when you're deliberately *not* spending
+a Scholar query so they know the plan.
+
+## Step 2 - Have the user launch and authenticate Chrome (user-attended)
+
+Ask the user to run this (in Claude Code they can prefix with `!`), then log into Google in
+the window it opens:
+
+```
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --remote-debugging-port=9222 --user-data-dir="/tmp/chrome-debug" &
+```
+
+Then: open `https://scholar.google.com/scholar_labs/search?hl=en` in that window and sign in.
+
+Gotchas worth stating up front, because they silently waste the user's time:
+- If Chrome is **already running under their normal profile**, macOS routes the
+  `--remote-debugging-port` flag to the existing process and ignores it, so port 9222 stays
+  empty. Have them **Quit Chrome fully (Cmd-Q)** first. The throwaway `/tmp/chrome-debug`
+  profile keeps this separate from their everyday session.
+- Confirm the endpoint is live before doing anything else:
+  `curl -s http://localhost:9222/json | python3 -c "import sys,json;[print(t['title'],'|',t['url']) for t in json.load(sys.stdin) if t['type']=='page']"`
+  You want to see a `Google Scholar` tab on the `scholar_labs/search` URL.
+
+## Step 3 - Install the one dependency
+
+The bundled script attaches over CDP, so no browser download is needed, only the package:
+
+```
+uv pip install playwright   # or: pip install playwright
+```
+
+## Step 4 - Phrase the query for a retrieval engine
+
+Scholar Labs *retrieves papers*; it does not synthesize opinions. Compound or comparative
+questions ("do X reviewers outperform Y; also consider Z?") with semicolons tend to get
+**bounced** with "Scholar Labs is currently not designed for queries like this." Rephrase as
+a single focused retrieval ask.
+
+**Example 1:**
+Input: Empirical evidence that human experts detect and correct LLM errors in text-to-SQL; do reviewers outperform the model alone?
+Output: human-in-the-loop validation accuracy of AI-generated SQL queries
+
+**Example 2:**
+Input: What's the best way to define workforce agility and is it the same as IT agility or not?
+Output: definitions of workforce agility in organizational research
+
+Draft the queries, show them to the user, and get a thumbs-up *before* spending quota.
+
+## Step 5 - Run the search (this spends one query)
+
+Each fresh query starts a clean session automatically (the script navigates to the base
+search URL first, so a previous query cannot contaminate this one - a real failure mode of
+naive automation that reuses the open box).
+
+```
+uv run python ~/.claude/skills/scholar-labs-search/scripts/scholar_search.py --query "your focused query"
+```
+
+The script prints JSON: `{url, result_count, status, body, sources[]}`.
+- `status: "ok"` with a non-null `result_count` (e.g. 10) means real results.
+- `status: "bounced"` means rephrase (Step 4) - this still consumed a query, so pause and
+  fix the wording before retrying.
+- `status: "needs_auth"` / `"no_chrome"` means go back to Step 2.
+
+Out of quota? The user can sign into a **second Google account** and you re-run with
+`--authuser 1` for a fresh allotment.
+
+## Step 6 - The free re-read (use this constantly)
+
+Results render a beat *after* the page first updates. If an extraction looks empty or shows a
+stale "Found 0 / not designed for queries like this" block but the browser visibly has
+results, **do not re-query**. Re-read the live page for free:
+
+```
+uv run python ~/.claude/skills/scholar-labs-search/scripts/scholar_search.py --read-only
+```
+
+This is the single most important habit: a "0 results" from the script is often an early-read
+artifact, not the truth. Confirm by re-reading before you ever conclude a gap exists.
+
+## Step 7 - Record the results (follow the project's convention)
+
+This skill returns raw findings; recording them is project-specific. If the repo has a
+research-provenance system (an answers/ directory of `Research_*.md` files, a questions index,
+a rule that every claim traces to a source URL), write the findings there with full citation
+metadata and source URLs, and update the index. Otherwise, summarize the `sources[]` with
+their URLs for the user. Mark a question as a genuine literature *gap* only after a clean,
+non-bounced search returned nothing - never after a bounce or an early-read 0.
+
+## Quick reference
+
+| Need | Command | Quota |
+|------|---------|-------|
+| Check endpoint | `curl -s http://localhost:9222/json` | free |
+| New search | `scholar_search.py --query "..."` | 1 query |
+| Re-read current page | `scholar_search.py --read-only` | free |
+| Second account | add `--authuser 1` | 1 query (other account) |

--- a/user-skills/research/scholar-labs-search/scripts/scholar_search.py
+++ b/user-skills/research/scholar-labs-search/scripts/scholar_search.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 stharrold
+# SPDX-License-Identifier: Apache-2.0
+"""
+Google Scholar Labs search over a user-authenticated Chrome (CDP).
+
+This script attaches to a Chrome you launched with --remote-debugging-port
+(it does NOT launch or authenticate Chrome itself; Google auth is user-attended).
+It supports two modes:
+
+  --read-only            Extract results already on the current Scholar Labs tab.
+                         Costs ZERO quota. Use this to re-read a page whose results
+                         rendered after an earlier extraction fired too early.
+
+  --query "TEXT"         Start a FRESH session (navigates to the base search URL so
+                         the previous query can't contaminate this one), submit TEXT,
+                         wait for results to render, then extract. COSTS ONE QUERY of
+                         the Scholar Labs daily quota (typically 3/day per account).
+
+Output: JSON on stdout (or to --out FILE): {url, result_count, status, body, sources[]}.
+Each source is {title, url}. The script never writes Markdown answer files itself;
+the caller decides how to record results (project conventions vary).
+
+Examples:
+  uv run python scholar_search.py --read-only
+  uv run python scholar_search.py --query "human-in-the-loop validation accuracy of AI-generated SQL"
+  uv run python scholar_search.py --query "..." --authuser 1   # second Google account
+"""
+
+import argparse
+import asyncio
+import json
+import sys
+
+from playwright.async_api import async_playwright
+
+BASE = "https://scholar.google.com/scholar_labs/search?hl=en"
+
+
+def base_url(authuser):
+    return BASE if authuser is None else f"{BASE}&authuser={authuser}"
+
+
+async def _find_or_open(ctx, authuser):
+    for pg in ctx.pages:
+        if "scholar_labs" in pg.url:
+            return pg
+    pg = await ctx.new_page()
+    await pg.goto(base_url(authuser))
+    return pg
+
+
+async def _extract(page):
+    """Read-only: pull body text + external source anchors from the current page."""
+    body = await page.locator("body").inner_text()
+
+    # The page can show a stale '--query / Found 0 relevant results' sub-block from a
+    # prior search ABOVE the real one. Report the LAST 'Found N relevant results'.
+    result_count = None
+    for line in body.splitlines():
+        s = line.strip().lower()
+        if "relevant result" in s:
+            for tok in s.replace("found", "").split():
+                if tok.isdigit():
+                    result_count = int(tok)
+
+    status = "ok"
+    if "not designed for queries like this" in body.lower():
+        status = "bounced"  # rephrase needed (often a compound/comparative question)
+    if "sign in" in body.lower() and "scholar labs" not in body.lower():
+        status = "needs_auth"
+
+    sources, seen = [], set()
+    anchors = page.locator("a")
+    for i in range(await anchors.count()):
+        try:
+            href = await anchors.nth(i).get_attribute("href")
+            txt = (await anchors.nth(i).text_content() or "").strip()
+        except Exception:
+            continue
+        if not href or not href.startswith("http") or "google." in href:
+            continue
+        if len(txt) < 6 or txt.lower().startswith("[pdf]") or txt.lower().startswith("[html]"):
+            # the bare "[PDF] domain.com" anchors duplicate the titled ones; skip
+            continue
+        if href in seen:
+            continue
+        seen.add(href)
+        sources.append({"title": txt, "url": href})
+
+    return {"url": page.url, "result_count": result_count, "status": status, "body": body, "sources": sources}
+
+
+async def _submit_and_wait(page, query, authuser, timeout_s):
+    # Fresh session: navigate to base URL so the previous query cannot contaminate.
+    await page.goto(base_url(authuser))
+    box = page.locator("#gs_as_i_t, textarea, [role=combobox]").first
+    await box.wait_for(timeout=15000)
+    await box.fill(query)
+    await box.press("Enter")
+
+    # Poll until results render. 'Looking for results...' is the in-progress state.
+    waited = 0
+    while waited < timeout_s:
+        await page.wait_for_timeout(2000)
+        waited += 2
+        txt = (await page.locator("body").inner_text()).lower()
+        if "not designed for queries like this" in txt:
+            break
+        if "relevant result" in txt and "looking for results" not in txt:
+            break
+
+
+async def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("query", nargs="?", help="query text (positional; or use --query)")
+    ap.add_argument("--query", dest="query_flag", help="query text")
+    ap.add_argument("--read-only", action="store_true", help="extract current page only; spends NO quota")
+    ap.add_argument("--authuser", type=int, default=None, help="Google account index for a second account (quota reset)")
+    ap.add_argument("--port", type=int, default=9222)
+    ap.add_argument("--timeout", type=int, default=60, help="seconds to wait for results")
+    ap.add_argument("--out", help="write JSON here instead of stdout")
+    a = ap.parse_args()
+
+    query = a.query_flag or a.query
+    if not a.read_only and not query:
+        print("ERROR: provide a query, or pass --read-only.", file=sys.stderr)
+        sys.exit(2)
+
+    async with async_playwright() as p:
+        try:
+            browser = await p.chromium.connect_over_cdp(f"http://localhost:{a.port}")
+        except Exception:
+            print(json.dumps({"status": "no_chrome", "hint": f"Launch Chrome with --remote-debugging-port={a.port} and log into Google."}))
+            return
+        ctx = browser.contexts[0]
+        page = await _find_or_open(ctx, a.authuser)
+        await page.bring_to_front()
+
+        if not a.read_only:
+            await _submit_and_wait(page, query, a.authuser, a.timeout)
+
+        result = await _extract(page)
+
+    payload = json.dumps(result, indent=2)
+    if a.out:
+        with open(a.out, "w") as f:
+            f.write(payload)
+        print(f"wrote {a.out} (status={result['status']}, results={result['result_count']}, sources={len(result['sources'])})")
+    else:
+        print(payload)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/user-skills/workflow/branch-release.md
+++ b/user-skills/workflow/branch-release.md
@@ -1,0 +1,177 @@
+---
+name: branch-release
+description: Cut a release branch from develop, merge to main, tag, backmerge to develop, and rebase contrib/<user>. Run this when develop is ready to ship.
+---
+
+# Branch Release Skill
+
+Takes develop from "ready" to "tagged on main" and keeps all branches in sync.
+Four-stage flow: cut release → merge to main → backmerge to develop → rebase contrib.
+
+## Input
+
+The user may specify a version bump type: `patch`, `minor`, or `major`.
+If not specified, infer from the commits on develop since the last tag:
+- Any commit with `feat:` or `feat(...):`  → minor
+- Any commit with `BREAKING CHANGE` or `!:` → major
+- Otherwise → patch
+
+The user may also supply an explicit version (e.g. `v1.2.0`). If so, use it directly
+and skip the inference step.
+
+---
+
+## Checklist
+
+### Phase 1 -- Determine version
+
+```bash
+# Find the current highest semver tag
+git fetch --tags
+CURRENT=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+echo "Current tag: ${CURRENT}"
+```
+
+If no tags exist, start at `v0.1.0` (first release is always minor).
+
+Parse the version, apply the bump, and print the proposed next version:
+```
+Current : v1.2.3
+Bump    : minor
+Next    : v1.3.0
+```
+
+Ask the user to confirm the version before continuing if it was inferred
+(skip confirmation if the user supplied it explicitly).
+
+### Phase 2 -- Cut the release branch
+
+```bash
+git checkout develop
+git pull origin develop
+
+git checkout -b "release/v${NEXT}"
+git push -u origin "release/v${NEXT}"
+```
+
+### Phase 3 -- Merge release to main
+
+Create the PR:
+```bash
+gh pr create \
+  --repo <owner/repo> \
+  --base main \
+  --head "release/v${NEXT}" \
+  --title "release: v${NEXT}" \
+  --body "$(cat <<'EOF'
+## Release v${NEXT}
+
+Merging release/v${NEXT} into main.
+
+- Bump type: ${BUMP}
+- Base: develop @ $(git rev-parse --short HEAD)
+EOF
+)"
+```
+
+Then invoke `/pr-ship` behaviour for this PR:
+- Wait for CI (Phase 2 of pr-ship)
+- Fix any failures (Phase 3 of pr-ship)
+- Address reviewer comments (Phase 4 of pr-ship)
+- **Do NOT auto-merge** -- pause and tell the user the PR is ready,
+  then wait for explicit confirmation before merging.
+
+Reason: release merges to main are high-stakes; the user should click merge
+or give explicit approval ("go ahead") before this skill proceeds.
+
+After confirmed merge:
+
+```bash
+git checkout main
+git pull origin main
+```
+
+### Phase 4 -- Tag main
+
+```bash
+git tag "v${NEXT}" -m "release: v${NEXT}"
+git push origin "v${NEXT}"
+```
+
+Confirm the tag is visible:
+```bash
+git tag --sort=-v:refname | head -3
+```
+
+### Phase 5 -- Backmerge release to develop
+
+Create the backmerge PR:
+```bash
+gh pr create \
+  --repo <owner/repo> \
+  --base develop \
+  --head "release/v${NEXT}" \
+  --title "chore: backmerge v${NEXT} to develop" \
+  --body "Backmerge release/v${NEXT} into develop after main merge."
+```
+
+Wait for CI to pass, then merge:
+```bash
+gh pr merge <number> --repo <owner/repo> --merge --delete-branch
+```
+
+Use `--merge` (not `--squash`) for backmerges -- preserves the release commit
+on develop so git history is symmetric.
+
+If GitHub reports "No commits between develop and release/v${NEXT}" (nothing
+to backmerge), skip this step and note it in the summary.
+
+### Phase 6 -- Rebase contrib/<user> onto develop
+
+```bash
+git fetch origin develop
+git checkout contrib/<user>
+git pull origin contrib/<user>
+git rebase origin/develop
+git push --force-with-lease origin contrib/<user>
+```
+
+`--force-with-lease` is safe here: it aborts if the remote has commits you
+have not seen, protecting against accidentally overwriting someone else's push.
+
+If the rebase has conflicts:
+1. List the conflicting files.
+2. Resolve them (prefer develop's version for files that are part of the release;
+   prefer contrib's version for in-progress feature work).
+3. `git rebase --continue` after each conflict set.
+4. If the conflict is non-trivial, pause and surface it to the user.
+
+### Phase 7 -- Final report
+
+Print a summary:
+
+```
+Release complete
+---------------
+Version  : v${NEXT}
+Tag      : v${NEXT} on main ($(git rev-parse --short v${NEXT}))
+Backmerge: release/v${NEXT} -> develop  [merged | skipped]
+Contrib  : contrib/<user> rebased onto develop
+
+Branches now:
+  main            <- v${NEXT} (tagged)
+  develop         <- includes v${NEXT} backmerge
+  contrib/<user> <- rebased onto develop
+```
+
+---
+
+## Hard stops
+
+- Do not proceed past Phase 3 without explicit user confirmation of the merge.
+- Do not tag until `git pull origin main` confirms the release PR merged.
+- Do not use `--force` (without `-with-lease`) on any push.
+- If `develop` has uncommitted or unmerged feature work that should NOT be in
+  this release, stop and tell the user before cutting the release branch.
+- If the computed next version would be lower than the current highest tag
+  (e.g. user requests patch but CURRENT is already v2.0.0), pause and confirm.

--- a/user-skills/workflow/branch-start.md
+++ b/user-skills/workflow/branch-start.md
@@ -1,0 +1,120 @@
+---
+name: branch-start
+description: Create a timestamped feature branch and its own git worktree. Run this at the start of every new feature -- before writing any code.
+---
+
+# Branch Start Skill
+
+Creates a feature branch and an isolated git worktree for a single piece of work.
+The worktree keeps the main repo checkout clean while the feature is in progress.
+
+## Input
+
+The user must supply a short slug describing the feature. If they did not provide
+one, ask before proceeding:
+
+> "What's a short slug for this feature? (e.g. `add-ocr-engine`, `fix-model-download`)"
+
+Slugs use lowercase hyphens only. No underscores, no spaces, no uppercase.
+Strip the slug of any leading/trailing hyphens.
+
+---
+
+## Checklist
+
+### Step 1 -- Collect context
+
+Run these commands from the main repo checkout (not from inside a worktree):
+
+```bash
+# Confirm you are in the main repo, not a worktree
+git rev-parse --show-toplevel
+pwd
+
+# Repo name (used for the worktree directory)
+basename "$(git rev-parse --show-toplevel)"
+
+# Current branch (should be main, develop, or contrib/<user> -- not a feature branch)
+git branch --show-current
+
+# Confirm contrib/stharrold exists locally or on remote
+git branch -a | grep contrib/stharrold
+```
+
+If you are already inside a worktree (`pwd` differs from `--show-toplevel`):
+stop and tell the user. Branch creation must happen from the main checkout.
+
+If `contrib/stharrold` does not exist locally, fetch it:
+```bash
+git fetch origin contrib/stharrold:contrib/stharrold
+```
+
+### Step 2 -- Generate names
+
+```bash
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+echo "timestamp: ${TS}"
+```
+
+Compose the names:
+- **Branch**: `feature/${TS}_${SLUG}`  (e.g. `feature/20260605T163000Z_add-ocr-engine`)
+- **Worktree dir**: `../${REPO_NAME}_feature_${TS}_${SLUG}`
+  (e.g. `../claristra_feature_20260605T163000Z_add-ocr-engine`)
+
+Print both so the user can see them before any git commands run.
+
+### Step 3 -- Create the worktree and branch
+
+The feature branch starts from `contrib/stharrold` so the feature inherits
+any in-progress work that is already integrated but not yet on develop.
+
+```bash
+git worktree add \
+  "../${REPO_NAME}_feature_${TS}_${SLUG}" \
+  -b "feature/${TS}_${SLUG}" \
+  contrib/stharrold
+```
+
+Confirm success:
+```bash
+git worktree list
+```
+
+### Step 4 -- Push the branch to remote
+
+```bash
+cd "../${REPO_NAME}_feature_${TS}_${SLUG}"
+git push -u origin "feature/${TS}_${SLUG}"
+```
+
+### Step 5 -- Report and hand off
+
+Print a summary block the user can copy:
+
+```
+Worktree : ../${REPO_NAME}_feature_${TS}_${SLUG}
+Branch   : feature/${TS}_${SLUG}
+Base     : contrib/stharrold
+Remote   : pushed
+
+Next steps:
+  cd ../${REPO_NAME}_feature_${TS}_${SLUG}   # work here
+  /pr-ship                                    # when ready to merge
+```
+
+All subsequent work for this feature happens inside the worktree directory.
+The main repo checkout stays on its original branch and is undisturbed.
+
+---
+
+## Hard stops
+
+- Do not create a worktree if `git status` shows uncommitted changes in the main
+  repo -- commit or stash first.
+- Do not use `_` in slugs (worktree directory uses `_` as a separator between
+  the repo name, "feature", timestamp, and slug -- mixing in slug underscores
+  breaks that structure).
+- Do not create a feature branch from `main` or `develop` directly -- always
+  branch from `contrib/stharrold`.
+- If a worktree for this slug already exists (leftover from a previous attempt),
+  pause and ask the user whether to remove it or reuse it.

--- a/user-skills/workflow/pr-ship.md
+++ b/user-skills/workflow/pr-ship.md
@@ -1,0 +1,181 @@
+---
+name: pr-ship
+description: Push a feature branch, wait for CI, fix failures, address reviewer comments, merge, and clean up the merged worktree + local branch -- fully autonomous with pause points for judgment calls.
+---
+
+# PR Ship Skill
+
+Autonomously take a feature branch from "ready to push" to "merged". Works across
+any repo that uses GitHub Actions CI and gh CLI.
+
+## Checklist
+
+Work through each phase in order. Mark each task complete before moving to the next.
+Pause and surface to the user whenever a step requires judgment (see Phase 4).
+
+---
+
+### Phase 1 -- Ensure PR exists
+
+1. Run `git status` and `git branch --show-current` to confirm the working tree is
+   clean and you are on a feature branch.
+2. If there are uncommitted changes, commit them first (follow the repo's commit
+   conventions; check git log for style).
+3. Push the branch: `git push -u origin <branch>` (or just `git push` if tracking
+   is already set).
+4. Check whether a PR already exists:
+   `gh pr list --repo <owner/repo> --head <branch> --json number,url`
+   - If none exists: create one with `gh pr create --title "..." --body "..."`.
+     Use a HEREDOC for the body. Set base branch to develop (or main if no develop).
+   - If one exists: note its number and URL; proceed.
+5. Print the PR URL so it is visible in the conversation.
+
+---
+
+### Phase 2 -- Wait for CI
+
+Repeat until all checks complete (pass or fail) or 20 minutes have elapsed:
+
+```
+gh pr view <number> --repo <owner/repo> --json statusCheckRollup
+```
+
+- If status is QUEUED or IN_PROGRESS: wait 30 seconds, then check again.
+  Use a polling loop -- do NOT sleep longer than 30 s per iteration so you stay
+  responsive to early failures.
+- If all checks show SUCCESS: proceed to Phase 4.
+- If any check shows FAILURE: proceed to Phase 3.
+- If 20 minutes elapse with checks still running: pause and tell the user.
+
+---
+
+### Phase 3 -- Fix CI failures (loop back to Phase 2 when done)
+
+For each failing check:
+
+1. Get the run ID from the statusCheckRollup detailsUrl or:
+   `gh run list --repo <owner/repo> --branch <branch> --limit 5`
+2. Read the failure log:
+   `gh run view <run-id> --repo <owner/repo> --log-failed`
+3. Diagnose the root cause from the log. Common categories:
+   - **Compilation error**: fix the Swift/TS/Python source file directly.
+   - **Test failure**: read the test output, fix the failing assertion or the code
+     under test. Do NOT delete or skip tests to make CI pass.
+   - **Missing file / lock file**: generate and commit the missing artifact
+     (e.g. `npm install` for package-lock.json).
+   - **Build config error** (xcodegen, tsconfig, wrangler): fix the config file.
+   - **Flaky test / infrastructure timeout**: re-run once with
+     `gh run rerun <run-id> --repo <owner/repo>` before diagnosing further.
+4. Apply the fix, commit with a concise message, push.
+5. Return to Phase 2.
+
+If the same check fails 3 times with different error messages (indicating the fix
+is not converging): pause and explain the situation to the user before continuing.
+
+---
+
+### Phase 4 -- Address reviewer comments
+
+1. Fetch all open PR review comments:
+   ```
+   gh api repos/<owner/repo>/pulls/<number>/comments \
+     --jq '.[] | {id, path, line, body}'
+   ```
+   Also fetch top-level review bodies:
+   ```
+   gh pr view <number> --repo <owner/repo> --json reviews \
+     --jq '.reviews[] | {author: .author.login, state, body}'
+   ```
+
+2. For each comment, classify it:
+
+   **Mechanical** (fix autonomously):
+   - OOM / memory / performance fix with a clear correct approach
+   - Stale / misleading comment in code
+   - Deprecated API swap with obvious replacement
+   - Missing null check, defer, error cleanup
+   - Trailing slash, copy/paste bug, typo
+   - Test coverage gap with an obvious test to add
+
+   **Judgment required** (pause and surface to user):
+   - Architecture or design disagreement
+   - Request to change a tradeoff that was deliberately chosen
+   - Ambiguous requirement ("make this more robust")
+   - Comment that conflicts with a decision recorded in CLAUDE.md or a resolved OD
+   - Any comment you are not confident you can fix correctly in one pass
+
+3. Apply all mechanical fixes. Group logically related fixes into a single commit.
+   Push. Return to Phase 2 to let CI verify the fixes.
+
+4. For judgment-required comments: list them clearly (file, line, comment text,
+   why you are pausing) and wait for the user before continuing.
+
+---
+
+### Phase 5 -- Merge
+
+Only proceed when:
+- All CI checks show SUCCESS (re-run Phase 2 to confirm after the last push).
+- No open reviewer comments remain that you have not addressed or escalated.
+
+Merge:
+```
+gh pr merge <number> --repo <owner/repo> --squash --delete-branch
+```
+
+Use `--squash` unless the repo's CLAUDE.md or branch conventions specify otherwise
+(e.g. some repos prefer `--merge` to preserve individual commits).
+
+After merging, confirm with:
+```
+gh pr view <number> --repo <owner/repo> --json state,mergedAt
+```
+
+Print the merge confirmation so it is visible in the conversation.
+
+---
+
+### Phase 6 -- Clean up the merged feature branch
+
+`--delete-branch` removes the REMOTE branch, but feature work here lives in a git
+worktree, so two things linger and accumulate: the worktree directory and the local
+branch (a branch checked out in a worktree cannot be deleted by `--delete-branch`).
+After the merge is confirmed MERGED, clean both up -- from the repo's MAIN checkout,
+since you cannot remove the worktree you are standing in:
+
+```
+# cd to the main checkout first if cwd is inside the feature worktree
+git worktree remove <path-to-feature-worktree>   # no --force: refuses if dirty
+git branch -d <feature-branch>                    # safe -d: refuses if unmerged
+```
+
+Safety (do not weaken):
+- Use `git branch -d`, never `-D`. If `-d` refuses, the branch has commits not in
+  the merge target (e.g. work committed after the PR head merged) -- STOP and report
+  it; do not force-delete (those commits may exist only on this branch).
+- Use `git worktree remove` without `--force`. If it refuses (uncommitted or
+  untracked files), report the path for manual review instead of forcing.
+- Clean up ONLY the just-merged branch here -- never batch-delete other branches.
+
+---
+
+## Hard stops (always pause, never skip)
+
+- The user has explicitly said a comment requires their input in CLAUDE.md or earlier
+  in the conversation.
+- Fixing a CI failure would require deleting or skipping a test.
+- The fix touches a file the user marked as off-limits or out of scope.
+- The PR branch has diverged from its base (merge conflict): resolve or rebase, then
+  confirm with the user before pushing a force-push equivalent.
+- The PR targets main directly and the repo has a protect rule -- check first.
+
+## Tips
+
+- Always use `--repo <owner/repo>` on every `gh` command to avoid acting on the
+  wrong repo when worktrees or multiple remotes are involved.
+- `gh run view --log-failed` only shows the failed steps. Use `--log` (full log)
+  only when --log-failed is not enough to diagnose.
+- If CI checks have not appeared yet after a push, wait 15 s and re-poll --
+  GitHub takes a moment to enqueue checks.
+- Do not amend published commits. Always create new commits when fixing CI failures
+  on an open PR.

--- a/user-skills/workflow/release-pilot/SKILL.md
+++ b/user-skills/workflow/release-pilot/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: release-pilot
+description: >-
+  Autonomously drive a Python repo's release end to end through the
+  contrib -> develop -> release -> main branch topology, with review/CI
+  gates and an explicit human confirm before promoting to production.
+  Use when the user says "cut a release", "ship this", "run the release
+  pilot", "release vN.N.N", or asks to drive a PR through to main. Derives
+  all phase/progress from git state -- no TODO files, no state database.
+---
+
+# release-pilot
+
+Declarative playbook for driving a release. This skill is **policy and
+topology**; the engine is built-in tooling (native worktrees, `/loop`,
+`/code-review`, and the `superpowers` skills). Do not re-implement
+orchestration in code -- read the git state, decide the next step, act.
+
+## When this applies
+
+Use when piloting a change from a working branch all the way to a tagged
+`main` release. Skip for a single quick commit, or work that never leaves a
+feature branch.
+
+## Branch topology (authoritative)
+
+```
+release/<YYYYMMDDTHHMMSSZ>_<slug>   <- work branch (worktree); implementation
+   |  PR + gate-merge (autonomous)
+   v
+contrib/<user>
+   |  rebase onto develop, then PR + gate-merge (autonomous)
+   v
+develop
+   |  ===== EXPLICIT HUMAN CONFIRM REQUIRED =====
+   v
+release/vN.N.N                     <- version branch
+   |  PR + merge to main (confirm-gated), then tag vN.N.N on main
+   v
+main  (tag vN.N.N)
+   |  backmerge release/vN.N.N -> develop (autonomous)
+   v
+develop  ->  rebase contrib/<user> onto develop
+```
+
+Two distinct `release/*` namespaces -- keep them straight:
+
+- **Work branch** `release/<YYYYMMDDTHHMMSSZ>_<slug>`: timestamped, one per
+  change. Where code is written. Replaces the old `feature/*`.
+- **Version branch** `release/vN.N.N`: the production-promotion branch cut
+  from `develop`. Created only after the confirm gate.
+
+`<slug>` is hyphenated lowercase. Timestamp is UTC `date -u +%Y%m%dT%H%M%SZ`.
+
+## The gates (decided contract)
+
+| Gate | Type | Behavior |
+|---|---|---|
+| **Human reviews** | soft, 10-min ceiling | Poll `gh pr view <pr> --json reviews,reviewDecision` and unresolved threads. Address any review that arrives. **If none arrive within 10 minutes, proceed with the merge (merge-on-timeout). Do not block.** |
+| **CI checks** | hard | `gh pr checks <pr>` must be green (all required checks) before any merge, including the merge-on-timeout case. **On failure: auto-fix, repush, re-poll.** |
+| **`develop -> release -> main` promotion** | confirm | Stop and require explicit human confirmation before creating `release/vN.N.N`, merging to `main`, or tagging. This gate is confirm-driven -- it never auto-proceeds on a timeout. |
+
+Autonomy boundary: everything up to and including the merge into `develop`
+is autonomous (including merge-on-timeout). The production promotion is
+human-gated.
+
+### Polling, not sleeping
+
+Drive the 10-minute review window with `/loop` (self-paced) or repeated
+`gh pr checks <pr>` calls at ~60-270s cadence -- never a single fixed
+`sleep`. The 10 minutes is a **ceiling that ends early** the moment reviews
+land or CI goes green; it is not a mandatory wait.
+
+### Verify the gate; never trust a masked exit code (learned in #241)
+
+`gh pr checks <pr> --watch` returns non-zero on check failure -- but only
+if you read *its* exit code. **Never pipe it into `tail`/`head`**: the
+pipeline's status is the last command's (`tail`), so `$?` is always 0 and a
+network drop (`TLS handshake timeout`) silently reads as "all green". This
+masked a false pass during the first real run.
+
+Rules:
+- Capture gh's own exit: `gh pr checks <pr> --watch >log 2>&1; echo $?` (no
+  pipe), or check `${PIPESTATUS[0]}`.
+- A `--watch` that exits is a *hint*, not proof. Before any merge,
+  **re-verify each check's conclusion explicitly** with `gh pr checks <pr>`
+  and confirm `mergeStateStatus == CLEAN`. A watch that died on a network
+  error is "unknown", not "pass".
+
+### CI auto-fix loop
+
+On a red required check:
+1. Read the failing check's logs (`gh run view <run-id> --log-failed`).
+2. Fix in the worktree (lint/format via the repo's tooling; real test/build
+   breaks via `systematic-debugging`).
+3. Commit, push, re-poll. Repeat until green or clearly stuck (then stop and
+   report).
+
+## The sequence
+
+Determine the current step from git state (see Recovery), then execute from
+there. Do not restart from step 1 if a later branch/PR/tag already exists.
+
+1. **Worktree.** Create a worktree on `release/<ts>_<slug>` branched from
+   `contrib/<user>` (native worktree tooling or `using-git-worktrees`).
+2. **Implement.** Do the work in the worktree. For code changes use
+   `test-driven-development`; commit in logical units.
+3. **Self-review.** Run `/code-review` on the diff; address findings.
+4. **PR to contrib.** Open `release/<ts>_<slug> -> contrib/<user>`. Apply
+   the review soft-gate + CI hard-gate, then merge (autonomous).
+5. **Integrate to develop.** Rebase `contrib/<user>` onto `develop` if
+   behind; open `contrib/<user> -> develop`; gate-merge (autonomous).
+6. **=== CONFIRM GATE ===** Compute the next `vN.N.N` with the deterministic
+   `release-lib` helper `next_version_from_tag(base_branch="origin/main",
+   ref="origin/main")` -- diffing develop against `origin/main` captures
+   everything unreleased; using `base_branch="develop"` when HEAD is already
+   on develop produces an empty diff and freezes the version. Never guess the version. **Sanity-check the bump:**
+   the file-pattern heuristic only treats `src/**.py` as a feature, so a new
+   top-level package (e.g. `release_lib/`) is under-classified as PATCH when
+   it is really a MINOR -- flag the mismatch and offer the override. Present
+   the proposed version + the `origin/main...origin/develop` diff summary and
+   **wait for explicit human confirmation.**
+7. **Version branch + main.** Create `release/vN.N.N` from `develop`; bump
+   `pyproject.toml` to the chosen version and run `uv lock` so `uv.lock`
+   doesn't drift (commit both); open `release/vN.N.N -> main`; merge only
+   after confirm; then create an **annotated** tag `vN.N.N` on the merge
+   commit and push it.
+8. **Backmerge.** Open/merge `release/vN.N.N -> develop` (autonomous gate).
+9. **Re-sync contrib.** Rebase `contrib/<user>` onto `develop`.
+10. **Clean up.** Remove the worktree; delete the merged `release/*` branches
+    locally and on the remote.
+
+## Recovery (resume from git state, never from a file)
+
+Phase is a pure function of git observables. To resume, check in order:
+
+- Tag `vN.N.N` on `main` exists + open `release/vN.N.N -> develop` PR ->
+  step 8 (backmerge) or step 9 (re-sync contrib).
+- `release/vN.N.N` exists + open PR to `main` -> step 7 (awaiting confirm
+  has passed; finish merge/tag).
+- Open `contrib/<user> -> develop` PR -> step 5.
+- Open `release/<ts>_<slug> -> contrib` PR -> step 4.
+- Work branch exists, no PR -> step 3.
+- Detached HEAD or nothing in flight -> report state, ask the user; do not
+  guess.
+
+Do **not** create or read `TODO_*.md` or any AgentDB/DuckDB state. Those are
+deprecated; git + the GitHub PR/checks API are the only source of truth.
+
+## Built-ins this skill drives (don't reinvent)
+
+| Need | Use |
+|---|---|
+| Isolated worktree | native worktree tooling / `superpowers:using-git-worktrees` |
+| Review-window / CI polling | `/loop` (self-paced) |
+| Self-review a diff | `/code-review` |
+| Acting on review feedback | `superpowers:receiving-code-review` |
+| Finishing/merging a branch | `superpowers:finishing-a-development-branch` |
+| Verifying before "done" | `superpowers:verification-before-completion` |
+| Next version (deterministic) | `release-lib` semver helper (Tier 2, issue #240) |
+
+## Anti-patterns
+
+- A fixed `sleep` for the review window (use a polling ceiling).
+- Merging to `main`, creating `release/vN.N.N`, or tagging without explicit
+  confirm.
+- Merging on red required CI (CI is a hard gate even on review timeout).
+- Computing the next version by judgment instead of the semver helper.
+- Writing `TODO_*.md` / touching AgentDB to track progress.
+- Re-deriving phase from anything other than git + PR/checks state.


### PR DESCRIPTION
## Summary

- Add `user-skills/workflow/` (`release-pilot/`, `branch-release.md`, `branch-start.md`, `pr-ship.md`) and `user-skills/research/` (`scholar-labs-search/`) to track user-level Claude Code skills in stharrold-templates
- Add `scripts/install_user_skills.py`: installs to `~/.claude/skills/` from any machine; skip-on-update default, `--force` to pull upstream, `--target` to redirect
- Fix WORKFLOW.md bootstrap snippet: replace stale "copy from a working instance" note with `install_user_skills.py` command
- Add User Skills section to BUNDLES.md with full usage examples and bundle table
- Add Step 3 (user skills install) to README.md

## Test plan

- [ ] `python scripts/install_user_skills.py . --bundle workflow --dry-run` prints expected files
- [ ] `python scripts/install_user_skills.py . --bundle research --dry-run` prints `scholar-labs-search`
- [ ] `--bundle all` shows both bundles
- [ ] Re-running without `--force` skips existing files with skip message
- [ ] CI passes (tests + claude-review)

🤖 Generated with [Claude Code](https://claude.ai/code)