### PR TITLE
fix(bundles): harden release_lib.bundles robustness (#245)

### DIFF
--- a/release_lib/bundles.py
+++ b/release_lib/bundles.py
@@ -337,7 +337,10 @@ def copy_tree(source: Path, target: Path, rel_dir: str, *, dry_run: bool) -> int
     print(f"  {action} {rel_dir}")
     if not dry_run:
         if dst.exists():
-            shutil.rmtree(dst)
+            if dst.is_file() or dst.is_symlink():
+                dst.unlink()
+            else:
+                shutil.rmtree(dst)
         shutil.copytree(src, dst, dirs_exist_ok=True)
     return 1
 
@@ -440,10 +443,10 @@ def merge_pyproject_deps(target: Path, deps: list[str], *, dry_run: bool) -> int
         """)
         print(f"  CREATE pyproject.toml ({len(deps)} deps)")
         if not dry_run:
-            pyproject_path.write_text(content)
+            pyproject_path.write_text(content, encoding="utf-8")
         return 1
 
-    text = pyproject_path.read_text()
+    text = pyproject_path.read_text(encoding="utf-8")
 
     # Parse existing TOML to find current deps
     try:
@@ -475,33 +478,51 @@ def merge_pyproject_deps(target: Path, deps: list[str], *, dry_run: bool) -> int
         print("  MERGE pyproject.toml (0 deps added)")
         return 0
 
-    print(f"  MERGE pyproject.toml ({len(missing)} dep{'s' if len(missing) != 1 else ''} added)")
-
     if dry_run:
+        print(f"  MERGE pyproject.toml ({len(missing)} dep{'s' if len(missing) != 1 else ''} added)")
         return 1
 
     lines = text.splitlines(keepends=True)
+    inserted = False
 
     if section_key == "dependency-groups":
-        # Find the closing ] for [dependency-groups] dev = [...]
-        _insert_deps_into_array(lines, "[dependency-groups]", "dev", missing)
+        inserted = _insert_deps_into_array(lines, "[dependency-groups]", "dev", missing)
     elif section_key == "tool.uv":
-        _insert_deps_into_array(lines, "[tool.uv]", "dev-dependencies", missing)
-    else:
-        # Append a new section at the end
+        inserted = _insert_deps_into_array(lines, "[tool.uv]", "dev-dependencies", missing)
+
+    if not inserted:
+        if section_key is not None:
+            # Section exists but array is inline; inserting would bleed deps
+            # into the wrong section (cross-section state-machine bug).
+            print(f"  WARN {section_key} dev array appears inline; skipping dep merge")
+            return 0
+        # No existing dev section: append a new one.
         deps_str = "\n".join(f'    "{d}",' for d in sorted(missing))
         lines.append("\n[dependency-groups]\n")
         lines.append(f"dev = [\n{deps_str}\n]\n")
 
-    pyproject_path.write_text("".join(lines))
+    merged = "".join(lines)
+    try:
+        tomllib.loads(merged)
+    except Exception as exc:
+        print(f"  WARN post-write TOML validation failed ({exc}); pyproject.toml may be malformed")
+
+    pyproject_path.write_text(merged, encoding="utf-8")
+    print(f"  MERGE pyproject.toml ({len(missing)} dep{'s' if len(missing) != 1 else ''} added)")
     return 1
 
 
-def _insert_deps_into_array(lines: list[str], section_header: str, key: str, deps: list[str]) -> None:
+def _insert_deps_into_array(lines: list[str], section_header: str, key: str, deps: list[str]) -> bool:
     """Insert *deps* into a TOML array-of-strings in *lines* in-place.
 
     Locates *section_header* (e.g. ``[tool.uv]``), then the *key* = ``[`` line,
     then finds the closing ``]`` and inserts new entries just before it.
+
+    Returns True on success. Returns False (without modifying *lines*) when:
+    - the section or key is not found, or
+    - the array is inline (``key = ["a", "b"]`` on one line), which would
+      otherwise cause the closing ``]`` of a later section to be matched,
+      inserting deps into the wrong TOML table.
     """
     in_section = False
     found_key = False
@@ -509,15 +530,15 @@ def _insert_deps_into_array(lines: list[str], section_header: str, key: str, dep
 
     for i, line in enumerate(lines):
         stripped = line.strip()
-        # Track section headers
         if stripped.startswith("[") and not stripped.startswith("[["):
-            in_section = stripped == section_header or stripped.startswith(section_header.rstrip("]") + ".")
-            # Also match exact header
-            if stripped == section_header:
-                in_section = True
+            if found_key:
+                # We found the key but hit a new section before finding the
+                # closing ']' on its own line -- the array must be inline.
+                break
+            in_section = stripped == section_header
 
         if in_section and not found_key:
-            if stripped.startswith(f"{key}") and "=" in stripped:
+            if stripped.startswith(key) and "=" in stripped:
                 found_key = True
 
         if found_key:
@@ -525,10 +546,13 @@ def _insert_deps_into_array(lines: list[str], section_header: str, key: str, dep
                 insert_idx = i
                 break
 
-    if insert_idx is not None:
-        new_lines = [f'    "{d}",\n' for d in sorted(deps)]
-        for j, nl in enumerate(new_lines):
-            lines.insert(insert_idx + j, nl)
+    if insert_idx is None:
+        return False
+
+    new_lines = [f'    "{d}",\n' for d in sorted(deps)]
+    for j, nl in enumerate(new_lines):
+        lines.insert(insert_idx + j, nl)
+    return True
 
 
 def merge_gitignore(target: Path, source: Path, *, dry_run: bool) -> int:
@@ -541,14 +565,14 @@ def merge_gitignore(target: Path, source: Path, *, dry_run: bool) -> int:
 
     # Collect existing target lines
     if target_gi.exists():
-        existing_lines = set(target_gi.read_text().splitlines())
+        existing_lines = set(target_gi.read_text(encoding="utf-8").splitlines())
     else:
         existing_lines = set()
 
     # Collect candidate lines: workflow patterns + source .gitignore
     candidates: list[str] = list(GITIGNORE_WORKFLOW_PATTERNS)
     if source_gi.exists():
-        for line in source_gi.read_text().splitlines():
+        for line in source_gi.read_text(encoding="utf-8").splitlines():
             stripped = line.strip()
             if stripped and not stripped.startswith("#"):
                 candidates.append(stripped)
@@ -564,9 +588,9 @@ def merge_gitignore(target: Path, source: Path, *, dry_run: bool) -> int:
     if dry_run:
         return 1
 
-    with open(target_gi, "a") as f:
+    with open(target_gi, "a", encoding="utf-8") as f:
         if existing_lines:
-            if not target_gi.read_text().endswith("\n"):
+            if not target_gi.read_text(encoding="utf-8").endswith("\n"):
                 f.write("\n")
             f.write("\n# Added by apply_bundle\n")
         else:

--- a/tests/unit/test_apply_bundle.py
+++ b/tests/unit/test_apply_bundle.py
@@ -1,14 +1,18 @@
 # SPDX-FileCopyrightText: 2025 stharrold
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for scripts/apply_bundle.py."""
+"""Tests for scripts/apply_bundle.py and release_lib.bundles."""
 
 import subprocess
 import sys
+import textwrap
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT))
 from apply_bundle import BUNDLE_DEFINITIONS, resolve_bundles
+
+from release_lib.bundles import _insert_deps_into_array, copy_tree, merge_gitignore, merge_pyproject_deps
 
 
 def test_apply_bundle_help_exits_zero():
@@ -145,3 +149,78 @@ def test_resolve_bundles_deduplicates():
         "data-catalog",
         "full",
     }
+
+
+# ---------------------------------------------------------------------------
+# Robustness fixes (issue #245)
+# ---------------------------------------------------------------------------
+
+
+def test_copy_tree_handles_file_at_dst(tmp_path):
+    """copy_tree succeeds when the destination path already exists as a file."""
+    src_root = tmp_path / "src"
+    (src_root / "rel_dir").mkdir(parents=True)
+    (src_root / "rel_dir" / "a.txt").write_text("hello", encoding="utf-8")
+
+    dst_root = tmp_path / "dst"
+    dst_root.mkdir()
+    # Plant a regular file where copy_tree expects to create a directory.
+    (dst_root / "rel_dir").write_text("not-a-dir", encoding="utf-8")
+
+    copy_tree(src_root, dst_root, "rel_dir", dry_run=False)
+
+    assert (dst_root / "rel_dir").is_dir()
+    assert (dst_root / "rel_dir" / "a.txt").read_text(encoding="utf-8") == "hello"
+
+
+def test_insert_deps_inline_array_returns_false_and_leaves_lines_unchanged():
+    """_insert_deps_into_array returns False when dev is an inline array and
+    must not modify lines -- preventing cross-section dep bleed."""
+    content = textwrap.dedent("""\
+        [dependency-groups]
+        dev = ["ruff>=0.14.1"]
+
+        [project]
+        dependencies = [
+            "requests",
+        ]
+    """)
+    lines = content.splitlines(keepends=True)
+    original = list(lines)
+
+    result = _insert_deps_into_array(lines, "[dependency-groups]", "dev", ["pytest>=8.0.0"])
+
+    assert result is False
+    assert lines == original  # lines must be untouched
+
+
+def test_merge_pyproject_inline_array_warns_and_skips(tmp_path, capsys):
+    """merge_pyproject_deps warns and returns 0 when dev array is inline,
+    leaving pyproject.toml byte-identical to the original."""
+    original = '[dependency-groups]\ndev = ["ruff>=0.14.1"]\n'
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(original, encoding="utf-8")
+
+    ret = merge_pyproject_deps(tmp_path, ["pytest>=8.0.0"], dry_run=False)
+
+    assert ret == 0
+    assert "WARN" in capsys.readouterr().out
+    assert pyproject.read_text(encoding="utf-8") == original
+
+
+def test_merge_gitignore_utf8(tmp_path):
+    """merge_gitignore reads and writes .gitignore files with UTF-8 encoding."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / ".gitignore").write_text("*.log\n.env\n", encoding="utf-8")
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    (dst / ".gitignore").write_text("*.pyc\n", encoding="utf-8")
+
+    merge_gitignore(dst, src, dry_run=False)
+
+    result = (dst / ".gitignore").read_text(encoding="utf-8")
+    assert "*.log" in result
+    assert ".env" in result
+    assert "*.pyc" in result


### PR DESCRIPTION
Integrates #255 into develop. Closes #245.

## Summary

- **`copy_tree`**: unlink file/symlink at `dst` before `rmtree` (crash fix)
- **`_insert_deps_into_array`**: break on new `[section]` while `found_key=True` — prevents cross-section dep bleed when dev array is inline; returns `bool`
- **`merge_pyproject_deps`**: warn-and-skip on inline array instead of corrupting; post-write `tomllib` validation; accurate printed count; `encoding="utf-8"` everywhere
- **`merge_gitignore`**: `encoding="utf-8"` on all file I/O

Four new unit tests cover each fix; 283/283 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)