### PR TITLE
chore(release): bump version to 9.2.0

### DIFF
--- a/.claude/skills/workflow-utilities/CLAUDE.md
+++ b/.claude/skills/workflow-utilities/CLAUDE.md
@@ -1,10 +1,9 @@
 # workflow-utilities (tactical notes)
 
 Shared utility scripts used by all other workflow skills: VCS wrapper
-(`gh`/`az`), TODO archiver, directory structure creator, skill
-scaffolder, SPDX/ASCII pre-commit hooks, and version validator. See
-[`SKILL.md`](SKILL.md) for the canonical skill definition and
-per-script reference.
+(`gh`/`az`), directory structure creator, skill scaffolder, SPDX/ASCII
+pre-commit hooks, and version validator. See [`SKILL.md`](SKILL.md) for
+the canonical skill definition and per-script reference.
 
 This file holds only gotchas that cost someone >30 minutes to
 rediscover.
@@ -28,19 +27,6 @@ rediscover.
   fallback parameter was added in v8.7.0 to deduplicate three copies
   of the same detection logic scattered across workflow scripts.
   Always pass a fallback for robustness.
-
-### TODO archiver (`workflow_archiver.py`)
-
-- **Archive destination is `ARCHIVED/` in the main repo**, not the
-  worktree. TODO files survive worktree deletion and are the audit
-  trail for completed work.
-- **Filename format**: `ARCHIVED/<original-TODO-name>-<timestamp>.md`
-  where `<timestamp>` is the archive time, not the original creation
-  time. Deliberate -- you want to know when a TODO was closed, not
-  just when it was opened.
-- **Not idempotent on same-second re-archive.** If you archive the
-  same TODO twice in one second you'll get a name collision.
-  Doesn't actually happen in practice.
 
 ### Directory structure (`directory_structure.py`)
 

--- a/.claude/skills/workflow-utilities/README.md
+++ b/.claude/skills/workflow-utilities/README.md
@@ -10,219 +10,86 @@ children:
 
 # Workflow Utilities
 
-> **Shared utilities for all workflow skills - file operations, TODO management, VCS abstraction, and documentation tools**
-
-Workflow Utilities provides reusable utilities for common workflow tasks used across all skills. It includes file deprecation, directory structure creation, TODO file updates, workflow lifecycle management, VCS abstraction, and documentation maintenance tools.
-
-## Features
-
-- ✅ **File deprecation** - Archive old files (never delete directly)
-- ✅ **Directory standards** - Create compliant directory structure
-- ✅ **TODO file updates** - Atomic YAML frontmatter updates
-- ✅ **Workflow lifecycle** - Register/archive workflows in TODO.md manifest
-- ✅ **VCS abstraction** - GitHub (`gh`) and Azure DevOps (`az`) CLI wrapper functions
-- ✅ **Documentation tools** - Version validation, skill creation, doc sync
-- ✅ **Archive management** - List and extract archived files
+> **Shared utilities for all workflow skills -- VCS abstraction, file deprecation, pre-commit hooks, version validation, and skill scaffolding**
 
 ## Quick Start
 
-### Deprecate Files (Never Delete)
-
 ```bash
-# Archive old files with timestamp
-python .claude/skills/workflow-utilities/scripts/deprecate_files.py \
-  TODO_feature_*.md \
-  old-auth-flow \
-  src/old_auth.py tests/test_old_auth.py
+# Archive deprecated files
+uv run python .claude/skills/workflow-utilities/scripts/deprecate_files.py <desc> <files...>
 
-# Creates: ARCHIVED/20251103T143000Z_old-auth-flow.zip
+# List/extract archives
+uv run python .claude/skills/workflow-utilities/scripts/archive_manager.py list
+uv run python .claude/skills/workflow-utilities/scripts/archive_manager.py extract <archive>
+
+# Validate version consistency across SKILL.md files
+uv run python .claude/skills/workflow-utilities/scripts/validate_versions.py
 ```
 
-### Create Standard Directory
+## Features
 
-```bash
-# Create directory with CLAUDE.md, README.md, ARCHIVED/
-python .claude/skills/workflow-utilities/scripts/directory_structure.py \
-  planning/auth-system
-```
-
-### Update TODO Task Status
-
-```bash
-# Mark task as complete
-python .claude/skills/workflow-utilities/scripts/todo_updater.py \
-  TODO_feature_*.md \
-  impl_003 \
-  complete \
-  35  # context usage %
-```
-
-### Workflow Lifecycle Management
-
-```bash
-# Register new workflow in TODO.md manifest
-python .claude/skills/workflow-utilities/scripts/workflow_registrar.py \
-  TODO_feature_20251103T143000Z_auth.md \
-  feature \
-  auth-system \
-  --title "User Authentication System"
-
-# Archive completed workflow
-python .claude/skills/workflow-utilities/scripts/workflow_archiver.py \
-  TODO_feature_20251103T143000Z_auth.md \
-  --summary "Implemented OAuth2 authentication" \
-  --version "1.6.0"
-
-# Sync TODO.md with filesystem (recovery)
-python .claude/skills/workflow-utilities/scripts/sync_manifest.py
-```
+- **File deprecation** -- Archive old files (never delete directly)
+- **Directory standards** -- Create standard `CLAUDE.md` / `README.md` / `ARCHIVED/` structure
+- **Archive management** -- List and extract timestamped archives
+- **VCS abstraction** -- `gh`/`az` wrapper functions (shim over `release_lib.vcs`)
+- **Pre-commit hooks** -- SPDX headers, ASCII-only, skill structure validation
+- **Version validation** -- `validate_versions.py` checks all SKILL.md semver frontmatter
+- **Skill scaffolding** -- `create_skill.py` bootstraps a new skill directory
 
 ## Scripts Reference
 
 | Script | Purpose | When to Use |
 |--------|---------|-------------|
-| `deprecate_files.py` | Archive deprecated files | When replacing old implementations |
-| `directory_structure.py` | Create standard directory structure | When creating planning/, specs/ directories |
-| `todo_updater.py` | Update task status in TODO files | When marking tasks complete |
-| `archive_manager.py` | List and extract archives | When inspecting/recovering archived files |
-| `workflow_registrar.py` | Register workflow in TODO.md | Phase 1/2 (after creating TODO file) |
-| `workflow_archiver.py` | Archive workflow in TODO.md | Phase 4.4 (after PR merged) |
-| `sync_manifest.py` | Sync TODO.md with filesystem | Recovery/verification |
-| `validate_versions.py` | Validate version consistency | Before committing skill changes |
-| `create_skill.py` | Create new skill with official docs | When adding new skills (rare) |
-| `sync_skill_docs.py` | Semi-automated doc sync | After modifying a skill |
+| `deprecate_files.py` | Timestamp-archive files into `ARCHIVED/` | Replacing old implementations |
+| `directory_structure.py` | Create standard dir (`CLAUDE.md`, `README.md`, `ARCHIVED/`) | Creating `planning/`, `specs/` |
+| `archive_manager.py` | List and extract archives | Inspecting / recovering archived files |
+| `validate_versions.py` | Validate SKILL.md semver + WORKFLOW.md version | Before committing skill changes |
+| `create_skill.py` | Scaffold a new skill directory | Adding a new skill (rare) |
+| `check_spdx_headers.py` | Pre-commit: enforce Apache-2.0 SPDX headers | Run by pre-commit automatically |
+| `check_ascii_only.py` | Pre-commit: reject non-ASCII chars in `.py` files | Run by pre-commit automatically |
+| `check_skill_structure.py` | Pre-commit: require `SKILL.md`/`README.md`/`CLAUDE.md` per skill | Run by pre-commit automatically |
 
 ## VCS Layer
 
-**Wrapper functions for GitHub (`gh`) and Azure DevOps (`az`) CLIs:**
+A backward-compat shim over `release_lib.vcs` (extracted in issue #240).
+**New code should import from `release_lib.vcs` directly.**
 
 ```python
-from vcs import create_pr, get_contrib_branch
+from vcs import create_pr, get_contrib_branch, get_username
 
-branch = get_contrib_branch()  # auto-detects provider
+branch = get_contrib_branch()   # auto-detects provider (gh / az)
+username = get_username()
 
-# Create PR
 pr_url = create_pr(
     base=branch,
-    head="feature/20251103T143000Z_auth",
-    title="feat: auth system (v1.6.0)",
+    head="release/20251103T143000Z_auth",
+    title="feat: auth system",
     body="PR body",
 )
 ```
 
-**Uses:** Auto-detected VCS provider (GitHub or Azure DevOps) for all operations
-
-## Directory Standards
-
-All directories created by workflow-utilities follow standard structure:
-
-```
-directory/
-├── CLAUDE.md      # Context for Claude Code
-├── README.md      # Human-readable documentation
-└── ARCHIVED/      # Deprecated files (except if directory IS archived)
-    ├── CLAUDE.md
-    └── README.md
-```
-
-**Enforced by:** `directory_structure.py`
-
 ## Best Practices
 
 **File deprecation:**
-- ❌ Never delete files directly
-- ✅ Always use `deprecate_files.py` to archive
+- Never delete files directly
+- Use `deprecate_files.py` to archive with a timestamp
 
 **Directory creation:**
-- ❌ Don't manually create directories
-- ✅ Use `directory_structure.py` for consistency
-
-**TODO updates:**
-- ❌ Don't manually edit TODO YAML frontmatter
-- ✅ Use `todo_updater.py` for atomic updates
-
-**Workflow lifecycle:**
-- ❌ Don't manually update TODO.md manifest
-- ✅ Use `workflow_registrar.py` and `workflow_archiver.py`
+- Use `directory_structure.py` for consistency (creates required `CLAUDE.md` / `README.md` / `ARCHIVED/`)
 
 **Documentation maintenance:**
-- ❌ Don't update versions without validation
-- ✅ Use `validate_versions.py` before committing
-- ✅ Use `sync_skill_docs.py` after skill changes
+- Run `validate_versions.py` before committing skill changes
+- SKILL.md is the canonical definition; README.md is the quick-start summary
 
-**VCS operations:**
-- ✅ Use VCS wrapper functions via `from vcs import create_pr, get_contrib_branch`
+## Integration
 
-## Integration with Other Skills
+Skills that use workflow-utilities:
 
-**All skills depend on workflow-utilities:**
-
-- **bmad-planner:** Uses `directory_structure.py`
-- **speckit-author:** Uses `directory_structure.py`
-- **quality-enforcer:** Uses `validate_versions.py`
-- **git-workflow-manager:** Uses VCS abstraction (`vcs/`)
-- **initialize-repository:** Uses `directory_structure.py`, `create_skill.py` patterns
-
-## Examples
-
-### Complete Workflow Lifecycle
-
-```bash
-# Phase 1: Register workflow after BMAD planning
-python .claude/skills/workflow-utilities/scripts/workflow_registrar.py \
-  TODO_feature_20251103T143000Z_auth.md \
-  feature auth-system --title "User Authentication"
-
-# Phase 2-3: Update tasks during implementation
-python .claude/skills/workflow-utilities/scripts/todo_updater.py \
-  TODO_feature_20251103T143000Z_auth.md impl_001 complete
-
-# Phase 4.4: Archive after PR merged
-python .claude/skills/workflow-utilities/scripts/workflow_archiver.py \
-  TODO_feature_20251103T143000Z_auth.md \
-  --summary "Implemented OAuth2" --version "1.6.0"
-```
-
-### Documentation Maintenance
-
-```bash
-# Validate version consistency
-python .claude/skills/workflow-utilities/scripts/validate_versions.py --verbose
-
-# Sync documentation after skill update
-python .claude/skills/workflow-utilities/scripts/sync_skill_docs.py \
-  bmad-planner 5.2.0
-```
-
-## Constants and Rationale
-
-| Constant | Value | Rationale |
-|----------|-------|-----------|
-| ARCHIVED/ directory | All deprecated files | Preserve history, enable recovery |
-| Timestamp format | `YYYYMMDDTHHMMSSZ` | Sortable, parseable, no shell escaping |
-| TODO.md manifest | YAML frontmatter | Single source of truth, machine-readable |
-| VCS abstraction | Unified interface | Portability, maintainability |
+- **git-workflow-manager** -- VCS abstraction (`vcs/` shim)
+- **initialize-repository** -- `directory_structure.py`, `create_skill.py`
 
 ## Related Documentation
 
-- **[SKILL.md](SKILL.md)** - Complete technical documentation
-- **[CLAUDE.md](CLAUDE.md)** - Claude Code integration guide
-- **[CHANGELOG.md](CHANGELOG.md)** - Version history
-
-**See also:**
-- [WORKFLOW.md](../../WORKFLOW.md) - Complete workflow guide
-- [UPDATE_CHECKLIST.md](../../.claude/skills/UPDATE_CHECKLIST.md) - Skill update checklist
-
-## Contributing
-
-This skill is part of the workflow system. To update:
-
-1. Modify scripts in `scripts/`
-2. Update version in `SKILL.md` frontmatter
-3. Document changes in `CHANGELOG.md`
-4. Run validation: `python .claude/skills/workflow-utilities/scripts/validate_versions.py`
-5. Sync documentation: `python .claude/skills/workflow-utilities/scripts/sync_skill_docs.py workflow-utilities <version>`
-
-## License
-
-Part of the german repository workflow system.
+- **[SKILL.md](SKILL.md)** -- canonical skill definition and per-script reference
+- **[CLAUDE.md](CLAUDE.md)** -- gotchas and tactical notes
+- **[WORKFLOW.md](../../WORKFLOW.md)** -- three-tier workflow guide

--- a/.claude/skills/workflow-utilities/README.md
+++ b/.claude/skills/workflow-utilities/README.md
@@ -55,7 +55,7 @@ A backward-compat shim over `release_lib.vcs` (extracted in issue #240).
 **New code should import from `release_lib.vcs` directly.**
 
 ```python
-from vcs import create_pr, get_contrib_branch, get_username
+from release_lib.vcs import create_pr, get_contrib_branch, get_username
 
 branch = get_contrib_branch()   # auto-detects provider (gh / az)
 username = get_username()

--- a/BUNDLES.md
+++ b/BUNDLES.md
@@ -10,7 +10,7 @@ Bundle manifest for `stharrold-templates`. Each bundle is a named set of files t
 | **Tier 2 — library** | `release_lib` Python package (not shipped by any bundle; lives in this repo) | — |
 | **Tier 3 — CI** | GitHub Actions workflows (`tests.yml`, `claude-code-review.yml`, `secrets-example.yml`) | `ci` |
 
-`release-pilot` (`~/.claude/skills/release-pilot/`) is installed at the user level and is **not shipped by any bundle** — it is the policy/playbook layer that calls into `release_lib` (Tier 2) and drives the `git`-bundle skills (Tier 1).
+`release-pilot` (`~/.claude/skills/release-pilot/`) and other user-level skills live in `user-skills/` in this repo. Install them with `install_user_skills.py` — they are **not shipped by `apply_bundle.py`** because they target `~/.claude/skills/`, not a project repo.
 
 
 ## Usage
@@ -314,6 +314,41 @@ Ship a conservative `_headers` file for Cloudflare Pages with baseline CSP, HSTS
 **Do not use when:**
 - Your app runs on a non-Cloudflare platform that ignores `_headers`.
 - You have an existing carefully-tuned CSP that the template baseline would regress.
+
+---
+
+### User Skills
+
+User-level skills live in `user-skills/` and are installed to `~/.claude/skills/` (not a project repo). Use `scripts/install_user_skills.py`:
+
+```bash
+# Clone templates next to your repo (or into .tmp/)
+git clone https://github.com/stharrold/stharrold-templates.git .tmp/stharrold-templates
+
+# Workflow skills -- release-pilot, branch-release.md, branch-start.md, pr-ship.md
+python .tmp/stharrold-templates/scripts/install_user_skills.py .tmp/stharrold-templates --bundle workflow
+
+# Research skills -- scholar-labs-search (for repos that do literature search)
+python .tmp/stharrold-templates/scripts/install_user_skills.py .tmp/stharrold-templates --bundle research
+
+# All user skills
+python .tmp/stharrold-templates/scripts/install_user_skills.py .tmp/stharrold-templates --bundle all
+
+# Dry run first
+python .tmp/stharrold-templates/scripts/install_user_skills.py .tmp/stharrold-templates --bundle workflow --dry-run
+
+# Force overwrite existing skills (picks up upstream changes)
+python .tmp/stharrold-templates/scripts/install_user_skills.py .tmp/stharrold-templates --bundle workflow --force
+```
+
+**Bundles:**
+
+| Bundle | Skills installed |
+|--------|-----------------|
+| `workflow` | `release-pilot/` (SKILL.md), `branch-release.md`, `branch-start.md`, `pr-ship.md` |
+| `research` | `scholar-labs-search/` (SKILL.md + scripts/) |
+
+**Ownership:** Skip-on-update by default (local edits survive reinstall). `--force` to pull upstream changes.
 
 ---
 

--- a/BUNDLES.md
+++ b/BUNDLES.md
@@ -2,6 +2,17 @@
 
 Bundle manifest for `stharrold-templates`. Each bundle is a named set of files that can be applied to a target repository.
 
+## Three-tier model
+
+| Tier | Role | Bundle |
+|------|------|--------|
+| **Tier 1 — policy** | `release-pilot` skill (user-level, not bundled) + `git` bundle skills + sN slash commands | `git` |
+| **Tier 2 — library** | `release_lib` Python package (not shipped by any bundle; lives in this repo) | — |
+| **Tier 3 — CI** | GitHub Actions workflows (`tests.yml`, `claude-code-review.yml`, `secrets-example.yml`) | `ci` |
+
+`release-pilot` (`~/.claude/skills/release-pilot/`) is installed at the user level and is **not shipped by any bundle** — it is the policy/playbook layer that calls into `release_lib` (Tier 2) and drives the `git`-bundle skills (Tier 1).
+
+
 ## Usage
 
 ### Quick Start
@@ -49,11 +60,10 @@ python .tmp/stharrold-templates/scripts/apply_bundle.py .tmp/stharrold-templates
 
 ### `git` -- Git Workflow and Branch Management
 
-Skills, commands, and documentation for the `main <- develop <- contrib/* <- feature/*` branch workflow.
+Skills, commands, and documentation for the `main <- develop <- contrib/<user> <- release/<ts>_<slug>` branch workflow.
 
 **Skills (template-owned):**
 - `.claude/skills/git-workflow-manager/`
-- `.claude/skills/workflow-orchestrator/`
 - `.claude/skills/workflow-utilities/`
 
 **Commands (template-owned):**
@@ -307,29 +317,11 @@ Ship a conservative `_headers` file for Cloudflare Pages with baseline CSP, HSTS
 
 ---
 
-### `agentdb` -- Opt-in DuckDB workflow state tracking
-
-**NEW in v8.9**: broken out of the `full` bundle.
-
-AgentDB provides persistent state tracking for workflow transitions via a local DuckDB. Each invocation of `/workflow:s1-worktree` .. `/workflow:s4-backmerge` records its completion, enabling analytics queries over historical workflow state (which step a branch is in, how long phases took, cross-team dependency graphs).
-
-**This is opt-in.** Git branches and PR state are the authoritative source of workflow state for new projects. The downstream reference implementation (synavistra) explicitly removed AgentDB tracking and records the decision in its own CLAUDE.md. The `agentdb` bundle is kept for teams whose release processes benefit from the analytics layer -- it is NOT required for the `git` / `s1..s4` workflow to function.
-
-**Skill (template-owned):**
-- `.claude/skills/agentdb-state-manager/`
-
-**Merge files (user-owned):**
-- `pyproject.toml` -- adds `duckdb>=1.2.0` to `[dependency-groups] dev`
-
-**Schema stability**: the internal phase keys (`phase_v7x1_1_worktree` .. `phase_v7x1_4_backmerge`) are deliberately NOT renamed to match the sN slash-command names. They are stable dict keys in `PHASE_MAP` and row values in `agent_synchronizations`, kept for backward compatibility with existing AgentDB databases.
-
----
-
-### `full` -- Everything (except agentdb)
+### `full` -- Everything (except security-headers)
 
 All files from `git` + `secrets` + `ci` + `graphrag` (which includes `pipeline`) + `sql-pipeline` + `data-catalog`, plus additional skills and documentation.
 
-**Note (v8.9 breaking change)**: `agentdb-state-manager` is no longer bundled with `full`. Teams that want AgentDB tracking must apply `--bundle agentdb` explicitly. This was changed because the downstream reference (synavistra) removed AgentDB and the skill added ~200 lines of context load that most users don't need.
+**Note**: `security-headers` is **not** included in `full`. Its `_headers` file is user-owned (skip-on-update) and is intentionally kept separate so downstream customizations survive re-apply. Apply `--bundle security-headers` explicitly when needed.
 
 **Additional skills (template-owned):**
 - `.claude/skills/tech-stack-adapter/`
@@ -367,9 +359,9 @@ Traceability for the conventions shipped by these bundles. Each entry links back
 
 - **`v7x1_N` slash command prefixes renamed to `sN`** (step-N). `v7x1` was a historical workflow version identifier with no meaning for new users; `sN` reads as "step N" and matches the existing "Step X of 4" prose in the command descriptions.
 
-### AgentDB decision (v8.9)
+### AgentDB decision (removed in v9.1.0)
 
-- **`agentdb-state-manager` moved from `full` to its own opt-in `agentdb` bundle.** Synavistra's auto-memory records the decision: *"No AgentDB: DuckDB state tracking removed; git branches are the state."* The skill still works and is kept for teams that want analytics queries, but new projects are no longer opted-in by default.
+- **`agentdb-state-manager` skill deleted in #242.** Synavistra's auto-memory records the decision: *"No AgentDB: DuckDB state tracking removed; git branches are the state."* The skill was moved to opt-in in v8.9 and then deleted entirely in v9.1.0. Git branches + the GitHub PR/checks API are the authoritative source of workflow state.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ deleting stale entries over adding caveats.
   (synavistra) proved the stubs were actively harmful.
 - Architecture descriptions, stack diagrams, bundle maps.
   → [`BUNDLES.md`](BUNDLES.md) for bundle contents and file ownership.
-  → [`WORKFLOW.md`](WORKFLOW.md) for the v7x1/sN workflow guide.
+  → [`WORKFLOW.md`](WORKFLOW.md) for the three-tier model and workflow guide.
 - Transient state, release notes, commit logs → git history,
   [`CHANGELOG.md`](CHANGELOG.md), GitHub issues.
 - Per-skill reference docs → each skill's `SKILL.md` is the canonical
@@ -50,9 +50,9 @@ the rest.
 
 ## Branch structure
 
-`main` <- `develop` <- `contrib/stharrold` <- `feature/*`
+`main` <- `develop` <- `contrib/<user>` <- `release/<ts>_<slug>` (worktree)
 
-Always end sessions on `contrib/stharrold`.
+Always end sessions on `contrib/<user>` (e.g. `contrib/stharrold`).
 
 ## Commands
 
@@ -102,8 +102,6 @@ uv run python .claude/skills/.../scripts/*.py  # Run skill scripts
   - `!{cmd}` → `` !`cmd` ``
   - `{{args}}` → `$ARGUMENTS`
 - **Workflow slash-command prefixes were renamed in v8.9**: `v7x1_1-worktree` → `s1-worktree`, `v7x1_2-integrate` → `s2-integrate`, `v7x1_3-release` → `s3-release`, `v7x1_4-backmerge` → `s4-backmerge`. The `sN` prefix ("step N") is shorter and more descriptive.
-- **`record_sync.py` (AgentDB state manager) auto-initializes the database on first use.** Failures print `[WARN]` to stderr and exit 0 (non-blocking by design).
-- **AgentDB `init_database_if_needed` checks for the `agent_synchronizations` table**, not just file existence. Pass `--db-path` to `init_database.py` for custom paths.
 - **After deleting or renaming Python modules under `.claude/skills/`**, grep all `*.md` files under the skills directory for stale references (CLAUDE.md, README.md, SKILL.md frontmatter all show up in the grep).
 
 ---
@@ -114,7 +112,7 @@ This repo provides installable workflow bundles. See [BUNDLES.md](BUNDLES.md)
 for the authoritative catalog and file-ownership rules.
 
 Current bundles: `git`, `secrets`, `ci`, `pipeline`, `sql-pipeline`,
-`graphrag`, `data-catalog`, `full`.
+`graphrag`, `data-catalog`, `security-headers`, `full`.
 
 CLI:
 
@@ -129,4 +127,4 @@ python scripts/apply_bundle.py <source-repo> <target-repo> \
 - **`../library/`** is the reference implementation for secrets management patterns.
 - **`../synavistra/`** is the reference implementation for `claude-code-review.yml` and has proven several CLAUDE.md conventions used here.
 - **`scripts/secrets_run.py`** runs commands with secrets from the OS keyring (#169).
-- **AgentDB state manager** (`.claude/skills/agentdb-state-manager/`) has test coverage in `tests/skills/`. Kept as opt-in; no longer included in the `full` bundle as of v8.9.
+- **`release_lib/`** is the Tier-2 deterministic library (`semver.py`, `vcs/`, `bundles.py`). Not shipped by any bundle — it is the engine that the `git` bundle's skills and the `release-pilot` user skill call into.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,13 +147,14 @@ gh pr create \
 
 ### Workflow Tools
 
-This repository includes 6 active workflow skills in `.claude/skills/`:
-- `workflow-orchestrator`: Main coordinator.
-- `git-workflow-manager`: Git automation.
-- `tech-stack-adapter`: Stack detection.
-- `workflow-utilities`: Shared utilities.
-- `agentdb-state-manager`: State tracking.
-- `initialize-repository`: Repository bootstrapping.
+This repository includes 5 active workflow skills in `.claude/skills/`:
+- `git-workflow-manager`: Git automation (worktrees, PRs, semantic versioning).
+- `tech-stack-adapter`: Stack detection (`TEST_CMD`/`BUILD_CMD` emission).
+- `workflow-utilities`: Shared utilities (VCS wrapper, pre-commit hooks, version validator).
+- `claude-md-hygiene`: Enforces the "earn it" CLAUDE.md discipline.
+- `initialize-repository`: Meta-skill to bootstrap new repos with the full workflow system.
+
+The `release-pilot` policy skill lives at `~/.claude/skills/release-pilot/` (user-level, not bundled).
 
 ## AI Configuration Guidelines
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,23 @@
 
 Templates and utilities for MCP (Model Context Protocol) server configuration and agentic development workflows.
 
+## Three-tier model
+
+| Tier | What | Where |
+|------|------|--------|
+| **Tier 1 — policy** | `release-pilot` skill (declarative playbook: gates, topology, autonomy contract) | `~/.claude/skills/release-pilot/` (user-level, not bundled) |
+| **Tier 2 — library** | `release_lib` Python package (deterministic helpers: semver, VCS, bundle engine) | `release_lib/` in this repo |
+| **Tier 3 — CI** | GitHub Actions workflows (tests, Claude code-review) | `.github/workflows/` (shipped via `ci` bundle) |
+
+The `git` bundle ships Tier-1 **skills** (`git-workflow-manager`, `workflow-utilities`) and the sN slash commands. The `ci` bundle ships Tier-3 CI artifacts. `release-pilot` is installed separately at the user level.
+
 ## Features
 
-- **sN workflow** - Streamlined 4-step autonomous development process
+- **release-pilot skill** - User-level declarative playbook driving the full release cycle
+- **release_lib** - Deterministic Python helpers: `semver.py` (auto-bump), `vcs/` (gh/az), `bundles.py` (bundle engine)
 - **Claude Code Review** - Automated PR analysis via GitHub Actions
-- **AgentDB Tracking** - Persistent state and metrics using DuckDB
+- **Installable bundles** - `git`, `secrets`, `ci`, `pipeline`, `sql-pipeline`, `graphrag`, `data-catalog`, `security-headers`, `full`
 - **Containerized development** - Podman + uv + Python 3.12 for consistency
-- **AI-optimized documentation** - Modular guides (≤30KB per file) for context efficiency
-- **AI-agent native** - Optimized for Claude Code and MCP (Model Context Protocol)
 
 ## Prerequisites
 
@@ -76,13 +85,14 @@ Replace `--bundle git` with whichever bundles you need:
 
 | Bundle | What you get |
 |--------|-------------|
-| `git` | Branch workflow, slash commands, skills |
+| `git` | Branch workflow, slash commands, skills (Tier 1) |
 | `secrets` | Keyring-backed secrets management |
-| `ci` | GitHub Actions, containers, pre-commit |
+| `ci` | GitHub Actions, containers, pre-commit (Tier 3) |
 | `pipeline` | 6-stage document processing ETL |
 | `sql-pipeline` | SQL Server ETL with pyodbc, retry, resumption |
 | `graphrag` | Graph RAG retrieval (includes `pipeline`) |
-| `full` | Everything above + extra skills and docs |
+| `security-headers` | Cloudflare Pages baseline CSP / HSTS headers (not in `full`) |
+| `full` | All of the above except `security-headers` + extra skills/docs |
 
 **Or run manually:**
 
@@ -176,7 +186,7 @@ See `secrets.toml` for secret definitions.
 │   ├── guides/             # Production guides
 │   ├── research/           # Exploratory documents
 │   └── reference/          # Reference materials
-├── .claude/skills/         # AI workflow skills (6 active)
+├── .claude/skills/         # AI workflow skills (5 active)
 ├── scripts/                # Utility scripts (secrets, run helpers)
 └── ARCHIVED/               # Archived specs, planning docs, deprecated code
 ```

--- a/README.md
+++ b/README.md
@@ -112,6 +112,23 @@ rm -rf .tmp/stharrold-templates
 
 See [BUNDLES.md](BUNDLES.md) for bundle contents, file ownership, and update behavior.
 
+### Step 3: Install user-level skills (optional)
+
+User skills (`release-pilot`, `scholar-labs-search`, etc.) install to `~/.claude/skills/` on your machine -- not into any specific repo. Install once per machine, then they are available everywhere:
+
+```bash
+# Workflow skills (release-pilot, branch-release, branch-start, pr-ship):
+python .tmp/stharrold-templates/scripts/install_user_skills.py .tmp/stharrold-templates --bundle workflow
+
+# Research skills (scholar-labs-search) -- for repos that use academic literature search:
+python .tmp/stharrold-templates/scripts/install_user_skills.py .tmp/stharrold-templates --bundle research
+
+# Dry run to preview:
+python .tmp/stharrold-templates/scripts/install_user_skills.py .tmp/stharrold-templates --bundle workflow --dry-run
+```
+
+Existing local skills are skipped by default; use `--force` to pull upstream changes.
+
 ## Secrets Management
 
 Cross-platform secrets management using environment variables with keyring fallback.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,15 +1,19 @@
-# Workflow Guide - sN (Implementation)
+# Workflow Guide
 
-**Version:** 7.0.0
-**Date:** 2026-01-01
-**Architecture:** 4-phase workflow using Claude Code
+**Version:** 9.1.1
 
-## Overview
+## Three-tier model
 
-This repository uses a streamlined 4-phase workflow for Python development:
-- **Git-flow hybrid** with worktrees for isolation
-- **Claude Code** for planning, architecture, and implementation
-- **No separate manual quality gates** (Claude Code Review automated via GitHub Actions)
+| Tier | Role | Location |
+|------|------|----------|
+| **Tier 1 — policy** | `release-pilot` skill: declarative playbook (gates, topology, autonomy contract) | `~/.claude/skills/release-pilot/` (user-level) |
+| **Tier 2 — library** | `release_lib`: deterministic Python helpers (`semver.py`, `vcs/`, `bundles.py`) | `release_lib/` in this repo |
+| **Tier 3 — CI** | GitHub Actions: `tests.yml`, `claude-code-review.yml`, `secrets-example.yml` | `.github/workflows/` (shipped via `ci` bundle) |
+
+**The product is the three tiers**, not the sN slash commands. The sN commands
+(`/workflow:s1-worktree` .. `/workflow:s4-backmerge`) are low-level helpers shipped
+by the `git` bundle; `release-pilot` drives them as needed. For a full release cycle,
+invoke `release-pilot` via the `Skill` tool.
 
 ## Prerequisites
 
@@ -22,170 +26,156 @@ Required tools:
 
 Verify prerequisites:
 ```bash
-# GitHub CLI:
 gh auth status          # Must be authenticated
-
 uv --version            # Must be installed
 python3 --version       # Must be 3.11+
 ```
 
-## Phase 0: Bootstrapping a New Repository
-
-This repository provides a meta-skill to bootstrap other projects with this workflow system.
-
-### From This Repository
-```bash
-python .claude/skills/initialize-repository/scripts/initialize_repository.py . /path/to/new-repo
-```
-
-### From a Cloned Release
-If you have cloned `stharrold-templates` into a subdirectory (e.g., `.tmp/`):
-```bash
-python .tmp/stharrold-templates/.claude/skills/initialize-repository/scripts/apply_workflow.py .tmp/stharrold-templates .
-```
-
-## sN workflow
+## Branch topology
 
 ```
-/workflow:s1-worktree "feature description"
-    | creates worktree, user implements feature in worktree
-    v
-/workflow:s2-integrate "feature/YYYYMMDDTHHMMSSZ_slug"
-    | PR feature->contrib->develop
-    v
-/workflow:s3-release
-    | create release, PR to main, tag
-    v
-/workflow:s4-backmerge
-    | PR release->develop, rebase contrib, manual cleanup
+release/<YYYYMMDDTHHMMSSZ>_<slug>   <- work branch (worktree)
+   |  PR + gate-merge (autonomous; release-pilot drives this)
+   v
+contrib/<user>                       <- personal integration (e.g. contrib/stharrold)
+   |  rebase onto develop, PR + gate-merge (autonomous)
+   v
+develop
+   |  ===== EXPLICIT HUMAN CONFIRM REQUIRED =====
+   v
+release/vN.N.N                      <- version branch (cut from develop)
+   |  PR to main; confirm-gated
+   v
+main  (tag vN.N.N)
+   |  backmerge release/vN.N.N -> develop (autonomous)
+   v
+develop  ->  rebase contrib/<user> onto develop
+```
+
+Work branches (`release/<ts>_<slug>`) replace the old `feature/*` naming.
+Two distinct `release/*` namespaces: timestamped work branches vs. versioned
+promotion branches (`release/vN.N.N`).
+
+### Branch protection
+
+**Protected (PR-only):** `main`, `develop`
+
+**Editable:** `contrib/*`, `release/<ts>_<slug>`
+
+**Ephemeral:** `release/vN.N.N` — deleted after backmerge completes.
+
+## Gates (decided contract)
+
+| Gate | Type | Behavior |
+|------|------|----------|
+| Human reviews | soft, 10-min ceiling | Poll `gh pr view --json reviews`. Merge on timeout if CI is green. |
+| CI checks | hard | `gh pr checks` must be green before any merge. Auto-fix on failure. |
+| `develop -> release -> main` | confirm | Stop; require explicit human confirmation before creating `release/vN.N.N` or tagging. |
+
+## Starting a release
+
+Invoke via Skill tool:
+
+```
+Skill("release-pilot")
+```
+
+`release-pilot` reads git state, determines current phase, and drives forward.
+For the specific steps it executes see `~/.claude/skills/release-pilot/SKILL.md`.
+
+## sN slash commands (low-level)
+
+The sN commands are building blocks used by `release-pilot`; you can also invoke them directly:
+
+```
+/workflow:s1-worktree "feature description"   # Create worktree on release/<ts>_<slug>
+/workflow:s2-integrate "release/<ts>_<slug>"  # PR work->contrib->develop
+/workflow:s3-release                          # Cut release/vN.N.N, PR->main, tag
+/workflow:s4-backmerge                        # PR release/vN.N.N->develop, cleanup
 ```
 
 ### Step 1: Create Worktree (`/workflow:s1-worktree`)
 
-Creates isolated git worktree for feature development.
+Creates an isolated git worktree on a `release/<ts>_<slug>` branch from `contrib/<user>`.
 
 ```bash
 /workflow:s1-worktree "add user authentication"
 ```
 
-**Output:**
-- Branch: `feature/{timestamp}_{slug}`
-- Worktree: `../{project}_feature_{timestamp}_{slug}/`
+**Output:** Branch `release/<timestamp>_<slug>`, worktree at `../<project>_release_<timestamp>_<slug>/`
 
-**Next steps displayed:** Navigate to worktree and implement the feature.
+### Step 2: Integrate (`/workflow:s2-integrate`)
 
-### Step 2: Feature Implementation
-
-Run in the feature worktree (not main repo) using Claude Code:
+From the main repo after implementation is complete:
 
 ```bash
-cd <worktree-path>
-# Then just chat with Claude Code:
-"Implement user authentication with JWT tokens"
-```
-
-**Claude Code handles:**
-- Understanding the codebase
-- Planning the implementation
-- Writing code and tests
-- Refinement
-
-No separate planning documents needed.
-
-### Step 3: Integrate (`/workflow:s2-integrate`)
-
-From main repo, after implementation is complete:
-
-```bash
-/workflow:s2-integrate "feature/20251229T120000Z_add-user-auth"
+/workflow:s2-integrate "release/20251229T120000Z_add-user-auth"
 ```
 
 **Two modes:**
-- **Full mode** (with branch arg): PR feature->contrib, manual worktree cleanup, manual branch cleanup, PR contrib->develop
+- **Full mode** (with branch arg): PR work->contrib, worktree cleanup, PR contrib->develop
 - **Contrib-only mode** (no arg): PR contrib->develop only
 
-**Manual gates:** PRs require approval in GitHub UI.
-
-### Step 4: Release (`/workflow:s3-release`)
-
-Creates release from develop:
+### Step 3: Release (`/workflow:s3-release`)
 
 ```bash
-/workflow:s3-release           # Auto-calculate version
-/workflow:s3-release v1.2.0    # Explicit version
+/workflow:s3-release           # auto-calculate version via release_lib.semver
+/workflow:s3-release v1.2.0    # explicit version
 ```
 
-**Creates:**
-- Branch: `release/{version}` from develop
-- PR to main (requires approval)
-- Tag on main after merge
+Creates `release/vN.N.N` from develop, PRs to main, tags on merge.
 
-### Step 5: Backmerge (`/workflow:s4-backmerge`)
-
-Syncs release changes back:
+### Step 4: Backmerge (`/workflow:s4-backmerge`)
 
 ```bash
 /workflow:s4-backmerge
 ```
 
-**Actions:**
-- PR release->develop (requires approval)
-- Rebases contrib on develop
-- Instructs manual deletion of release branch
+PRs `release/vN.N.N -> develop`, rebases `contrib/<user>` onto develop, deletes the release branch.
 
-## Branch Structure
+## Bootstrapping a new repository
 
-```
-main                           <- Production (tagged vX.Y.Z)
-  ^
-release/vX.Y.Z                <- Release candidate (ephemeral)
-  ^
-develop                        <- Integration branch
-  ^
-contrib/<gh-user>             <- Personal contribution (contrib/stharrold)
-  ^
-feature/<timestamp>_<slug>    <- Isolated feature (worktree)
+Apply the `git` bundle (Tier 1 skills + sN commands + `WORKFLOW.md` + `CONTRIBUTING.md`):
+
+```bash
+cd /path/to/new-repo
+git clone https://github.com/stharrold/stharrold-templates.git .tmp/stharrold-templates
+uv run python .tmp/stharrold-templates/scripts/apply_bundle.py .tmp/stharrold-templates . --bundle git
+rm -rf .tmp/stharrold-templates
 ```
 
-### Branch Protection
+For the full workflow system (all tiers):
 
-**Protected branches (PR-only):**
-- `main` - Production
-- `develop` - Integration
+```bash
+# Tier 1+3: apply git + ci bundles
+cd /path/to/new-repo
+git clone https://github.com/stharrold/stharrold-templates.git .tmp/stharrold-templates
+uv run python .tmp/stharrold-templates/scripts/apply_bundle.py .tmp/stharrold-templates . --bundle git --bundle ci
+rm -rf .tmp/stharrold-templates
 
-**Editable branches:**
-- `contrib/*` - Personal contribution
-- `feature/*` - Feature development
+# Tier 1 policy skill: install release-pilot separately (user-level)
+# Copy ~/.claude/skills/release-pilot/ from a working instance or craft from SKILL.md.
+```
 
-**Ephemeral branches:**
-- `release/*` - Created in `/workflow:s3-release`, manually deleted after `/workflow:s4-backmerge`
+Or use `initialize-repository` to interactively scaffold a complete project:
 
-## Key Differences from v1-v7
+```bash
+uv run python .claude/skills/initialize-repository/scripts/initialize_repository.py . /path/to/new-repo
+```
 
-| Aspect | v1-v7 | sN |
-|--------|-------|-----|
-| Planning | BMAD documents + SpecKit specs | Built-in Claude Code tools |
-| Quality gates | 5 separate gates | Claude Code Review |
-| Steps | 7 phases | 4 steps |
-| Artifacts | requirements.md, architecture.md, spec.md, plan.md | None (Claude Code handles internally) |
+## Skills
 
-## Skills System
+| Skill | Bundle | Purpose |
+|-------|--------|---------|
+| `release-pilot` | user-level (not bundled) | Declarative release playbook; drives the full cycle |
+| `git-workflow-manager` | `git` | Worktrees, PR operations, semantic versioning helpers |
+| `workflow-utilities` | `git` | VCS wrapper (`gh`/`az`), pre-commit hooks, version validator |
+| `tech-stack-adapter` | `full` | Python/uv stack detection, `TEST_CMD`/`BUILD_CMD` emission |
+| `claude-md-hygiene` | not bundled (in-repo only) | Enforces the "earn it" CLAUDE.md discipline |
+| `initialize-repository` | `full` | Meta-skill: bootstraps a new repo with the full workflow system |
 
-| Skill | Purpose |
-|-------|---------|
-| workflow-orchestrator | Main coordinator, templates |
-| git-workflow-manager | Worktrees, PRs, semantic versioning |
-| tech-stack-adapter | Python/uv detection |
-| workflow-utilities | Archive, directory structure |
-| agentdb-state-manager | Workflow state tracking |
-| initialize-repository | Bootstrap new repos |
+## Related documentation
 
-**Archived skills** (see `ARCHIVED/`):
-- bmad-planner
-- speckit-author
-- quality-enforcer
-
-## Related Documentation
-
-- **[CLAUDE.md](CLAUDE.md)** - Main AI context file
+- **[CLAUDE.md](CLAUDE.md)** - Gotchas and key context for Claude Code sessions
+- **[BUNDLES.md](BUNDLES.md)** - Bundle catalog and file ownership rules
 - **[CHANGELOG.md](CHANGELOG.md)** - Version history

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -147,14 +147,14 @@ rm -rf .tmp/stharrold-templates
 For the full workflow system (all tiers):
 
 ```bash
-# Tier 1+3: apply git + ci bundles
+# Tier 1+3: apply git + ci bundles, then install user-level skills
 cd /path/to/new-repo
 git clone https://github.com/stharrold/stharrold-templates.git .tmp/stharrold-templates
 uv run python .tmp/stharrold-templates/scripts/apply_bundle.py .tmp/stharrold-templates . --bundle git --bundle ci
-rm -rf .tmp/stharrold-templates
 
-# Tier 1 policy skill: install release-pilot separately (user-level)
-# Copy ~/.claude/skills/release-pilot/ from a working instance or craft from SKILL.md.
+# Tier 1 policy skill: install release-pilot (user-level, installs to ~/.claude/skills/)
+python .tmp/stharrold-templates/scripts/install_user_skills.py .tmp/stharrold-templates --bundle workflow
+rm -rf .tmp/stharrold-templates
 ```
 
 Or use `initialize-repository` to interactively scaffold a complete project:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "stharrold-templates"
-version = "9.1.1"
+version = "9.2.0"
 description = "Templates and utilities for MCP server configuration and agentic development workflows"
 requires-python = ">=3.12"
 dependencies = [

--- a/release_lib/bundles.py
+++ b/release_lib/bundles.py
@@ -337,7 +337,10 @@ def copy_tree(source: Path, target: Path, rel_dir: str, *, dry_run: bool) -> int
     print(f"  {action} {rel_dir}")
     if not dry_run:
         if dst.exists():
-            shutil.rmtree(dst)
+            if dst.is_file() or dst.is_symlink():
+                dst.unlink()
+            else:
+                shutil.rmtree(dst)
         shutil.copytree(src, dst, dirs_exist_ok=True)
     return 1
 
@@ -440,10 +443,10 @@ def merge_pyproject_deps(target: Path, deps: list[str], *, dry_run: bool) -> int
         """)
         print(f"  CREATE pyproject.toml ({len(deps)} deps)")
         if not dry_run:
-            pyproject_path.write_text(content)
+            pyproject_path.write_text(content, encoding="utf-8")
         return 1
 
-    text = pyproject_path.read_text()
+    text = pyproject_path.read_text(encoding="utf-8")
 
     # Parse existing TOML to find current deps
     try:
@@ -475,33 +478,51 @@ def merge_pyproject_deps(target: Path, deps: list[str], *, dry_run: bool) -> int
         print("  MERGE pyproject.toml (0 deps added)")
         return 0
 
-    print(f"  MERGE pyproject.toml ({len(missing)} dep{'s' if len(missing) != 1 else ''} added)")
-
     if dry_run:
+        print(f"  MERGE pyproject.toml ({len(missing)} dep{'s' if len(missing) != 1 else ''} added)")
         return 1
 
     lines = text.splitlines(keepends=True)
+    inserted = False
 
     if section_key == "dependency-groups":
-        # Find the closing ] for [dependency-groups] dev = [...]
-        _insert_deps_into_array(lines, "[dependency-groups]", "dev", missing)
+        inserted = _insert_deps_into_array(lines, "[dependency-groups]", "dev", missing)
     elif section_key == "tool.uv":
-        _insert_deps_into_array(lines, "[tool.uv]", "dev-dependencies", missing)
-    else:
-        # Append a new section at the end
+        inserted = _insert_deps_into_array(lines, "[tool.uv]", "dev-dependencies", missing)
+
+    if not inserted:
+        if section_key is not None:
+            # Section exists but array is inline; inserting would bleed deps
+            # into the wrong section (cross-section state-machine bug).
+            print(f"  WARN {section_key} dev array appears inline; skipping dep merge")
+            return 0
+        # No existing dev section: append a new one.
         deps_str = "\n".join(f'    "{d}",' for d in sorted(missing))
         lines.append("\n[dependency-groups]\n")
         lines.append(f"dev = [\n{deps_str}\n]\n")
 
-    pyproject_path.write_text("".join(lines))
+    merged = "".join(lines)
+    try:
+        tomllib.loads(merged)
+    except Exception as exc:
+        print(f"  WARN post-write TOML validation failed ({exc}); pyproject.toml may be malformed")
+
+    pyproject_path.write_text(merged, encoding="utf-8")
+    print(f"  MERGE pyproject.toml ({len(missing)} dep{'s' if len(missing) != 1 else ''} added)")
     return 1
 
 
-def _insert_deps_into_array(lines: list[str], section_header: str, key: str, deps: list[str]) -> None:
+def _insert_deps_into_array(lines: list[str], section_header: str, key: str, deps: list[str]) -> bool:
     """Insert *deps* into a TOML array-of-strings in *lines* in-place.
 
     Locates *section_header* (e.g. ``[tool.uv]``), then the *key* = ``[`` line,
     then finds the closing ``]`` and inserts new entries just before it.
+
+    Returns True on success. Returns False (without modifying *lines*) when:
+    - the section or key is not found, or
+    - the array is inline (``key = ["a", "b"]`` on one line), which would
+      otherwise cause the closing ``]`` of a later section to be matched,
+      inserting deps into the wrong TOML table.
     """
     in_section = False
     found_key = False
@@ -509,15 +530,15 @@ def _insert_deps_into_array(lines: list[str], section_header: str, key: str, dep
 
     for i, line in enumerate(lines):
         stripped = line.strip()
-        # Track section headers
         if stripped.startswith("[") and not stripped.startswith("[["):
-            in_section = stripped == section_header or stripped.startswith(section_header.rstrip("]") + ".")
-            # Also match exact header
-            if stripped == section_header:
-                in_section = True
+            if found_key:
+                # We found the key but hit a new section before finding the
+                # closing ']' on its own line -- the array must be inline.
+                break
+            in_section = stripped == section_header
 
         if in_section and not found_key:
-            if stripped.startswith(f"{key}") and "=" in stripped:
+            if stripped.startswith(key) and "=" in stripped:
                 found_key = True
 
         if found_key:
@@ -525,10 +546,13 @@ def _insert_deps_into_array(lines: list[str], section_header: str, key: str, dep
                 insert_idx = i
                 break
 
-    if insert_idx is not None:
-        new_lines = [f'    "{d}",\n' for d in sorted(deps)]
-        for j, nl in enumerate(new_lines):
-            lines.insert(insert_idx + j, nl)
+    if insert_idx is None:
+        return False
+
+    new_lines = [f'    "{d}",\n' for d in sorted(deps)]
+    for j, nl in enumerate(new_lines):
+        lines.insert(insert_idx + j, nl)
+    return True
 
 
 def merge_gitignore(target: Path, source: Path, *, dry_run: bool) -> int:
@@ -541,14 +565,14 @@ def merge_gitignore(target: Path, source: Path, *, dry_run: bool) -> int:
 
     # Collect existing target lines
     if target_gi.exists():
-        existing_lines = set(target_gi.read_text().splitlines())
+        existing_lines = set(target_gi.read_text(encoding="utf-8").splitlines())
     else:
         existing_lines = set()
 
     # Collect candidate lines: workflow patterns + source .gitignore
     candidates: list[str] = list(GITIGNORE_WORKFLOW_PATTERNS)
     if source_gi.exists():
-        for line in source_gi.read_text().splitlines():
+        for line in source_gi.read_text(encoding="utf-8").splitlines():
             stripped = line.strip()
             if stripped and not stripped.startswith("#"):
                 candidates.append(stripped)
@@ -564,9 +588,9 @@ def merge_gitignore(target: Path, source: Path, *, dry_run: bool) -> int:
     if dry_run:
         return 1
 
-    with open(target_gi, "a") as f:
+    with open(target_gi, "a", encoding="utf-8") as f:
         if existing_lines:
-            if not target_gi.read_text().endswith("\n"):
+            if not target_gi.read_text(encoding="utf-8").endswith("\n"):
                 f.write("\n")
             f.write("\n# Added by apply_bundle\n")
         else:

--- a/scripts/install_user_skills.py
+++ b/scripts/install_user_skills.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 stharrold
+# SPDX-License-Identifier: Apache-2.0
+"""
+Install user-level Claude Code skills from stharrold-templates into ~/.claude/skills/.
+
+Skills are copied from user-skills/<bundle>/ to --target (default: ~/.claude/skills/).
+Existing files are skipped by default; use --force to overwrite.
+
+Usage:
+    python scripts/install_user_skills.py <source_repo> [--bundle workflow] [--bundle research]
+    python scripts/install_user_skills.py <source_repo> --bundle all
+    python scripts/install_user_skills.py <source_repo> --bundle workflow --force
+    python scripts/install_user_skills.py <source_repo> --dry-run
+
+Bundles:
+    workflow  -- release-pilot, branch-release.md, branch-start.md, pr-ship.md
+    research  -- scholar-labs-search
+    all       -- all of the above
+"""
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+BUNDLES = {
+    "workflow": [
+        "release-pilot",
+        "branch-release.md",
+        "branch-start.md",
+        "pr-ship.md",
+    ],
+    "research": [
+        "scholar-labs-search",
+    ],
+}
+
+
+def _resolve_bundles(requested):
+    if "all" in requested:
+        return list(BUNDLES.keys())
+    unknown = set(requested) - set(BUNDLES)
+    if unknown:
+        print(f"ERROR: unknown bundle(s): {', '.join(sorted(unknown))}", file=sys.stderr)
+        print(f"Available: {', '.join(BUNDLES)}, all", file=sys.stderr)
+        sys.exit(1)
+    return list(requested)
+
+
+def _copy_entry(src, dst, force, dry_run, *, label):
+    """Copy a file or directory tree from src to dst, respecting skip-on-update."""
+    if dst.exists() and not force:
+        print(f"  skip   {label}  (exists; use --force to overwrite)")
+        return
+    action = "dry-run" if dry_run else ("overwrite" if dst.exists() else "install")
+    print(f"  {action:<9} {label}")
+    if dry_run:
+        return
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if src.is_dir():
+        if dst.exists():
+            shutil.rmtree(dst)
+        shutil.copytree(src, dst)
+    else:
+        shutil.copy2(src, dst)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("source_repo", type=Path, help="path to the stharrold-templates repo")
+    ap.add_argument("--bundle", action="append", default=[], metavar="NAME", help="bundle to install (workflow, research, all); repeatable")
+    ap.add_argument("--target", type=Path, default=Path.home() / ".claude" / "skills", help="destination directory (default: ~/.claude/skills/)")
+    ap.add_argument("--force", action="store_true", help="overwrite existing files")
+    ap.add_argument("--dry-run", action="store_true", help="show what would happen without writing")
+    args = ap.parse_args()
+
+    if not args.bundle:
+        ap.print_help()
+        print("\nERROR: at least one --bundle is required.", file=sys.stderr)
+        sys.exit(1)
+
+    bundles = _resolve_bundles(args.bundle)
+    user_skills_root = args.source_repo / "user-skills"
+
+    if not user_skills_root.is_dir():
+        print(f"ERROR: {user_skills_root} not found. Is source_repo correct?", file=sys.stderr)
+        sys.exit(1)
+
+    args.target.mkdir(parents=True, exist_ok=True)
+
+    print(f"Installing user skills -> {args.target}")
+    if args.force:
+        print("  (--force: existing files will be overwritten)")
+    if args.dry_run:
+        print("  (--dry-run: no files will be written)")
+    print()
+
+    for bundle_name in bundles:
+        bundle_dir = user_skills_root / bundle_name
+        print(f"[{bundle_name}]")
+        for entry_name in BUNDLES[bundle_name]:
+            src = bundle_dir / entry_name
+            dst = args.target / entry_name
+            if not src.exists():
+                print(f"  ERROR: source missing: {src}", file=sys.stderr)
+                sys.exit(1)
+            _copy_entry(src, dst, args.force, args.dry_run, label=entry_name)
+        print()
+
+    if args.dry_run:
+        print("Dry run complete. Rerun without --dry-run to apply.")
+    else:
+        print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_apply_bundle.py
+++ b/tests/unit/test_apply_bundle.py
@@ -1,14 +1,18 @@
 # SPDX-FileCopyrightText: 2025 stharrold
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for scripts/apply_bundle.py."""
+"""Tests for scripts/apply_bundle.py and release_lib.bundles."""
 
 import subprocess
 import sys
+import textwrap
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT))
 from apply_bundle import BUNDLE_DEFINITIONS, resolve_bundles
+
+from release_lib.bundles import _insert_deps_into_array, copy_tree, merge_gitignore, merge_pyproject_deps
 
 
 def test_apply_bundle_help_exits_zero():
@@ -145,3 +149,78 @@ def test_resolve_bundles_deduplicates():
         "data-catalog",
         "full",
     }
+
+
+# ---------------------------------------------------------------------------
+# Robustness fixes (issue #245)
+# ---------------------------------------------------------------------------
+
+
+def test_copy_tree_handles_file_at_dst(tmp_path):
+    """copy_tree succeeds when the destination path already exists as a file."""
+    src_root = tmp_path / "src"
+    (src_root / "rel_dir").mkdir(parents=True)
+    (src_root / "rel_dir" / "a.txt").write_text("hello", encoding="utf-8")
+
+    dst_root = tmp_path / "dst"
+    dst_root.mkdir()
+    # Plant a regular file where copy_tree expects to create a directory.
+    (dst_root / "rel_dir").write_text("not-a-dir", encoding="utf-8")
+
+    copy_tree(src_root, dst_root, "rel_dir", dry_run=False)
+
+    assert (dst_root / "rel_dir").is_dir()
+    assert (dst_root / "rel_dir" / "a.txt").read_text(encoding="utf-8") == "hello"
+
+
+def test_insert_deps_inline_array_returns_false_and_leaves_lines_unchanged():
+    """_insert_deps_into_array returns False when dev is an inline array and
+    must not modify lines -- preventing cross-section dep bleed."""
+    content = textwrap.dedent("""\
+        [dependency-groups]
+        dev = ["ruff>=0.14.1"]
+
+        [project]
+        dependencies = [
+            "requests",
+        ]
+    """)
+    lines = content.splitlines(keepends=True)
+    original = list(lines)
+
+    result = _insert_deps_into_array(lines, "[dependency-groups]", "dev", ["pytest>=8.0.0"])
+
+    assert result is False
+    assert lines == original  # lines must be untouched
+
+
+def test_merge_pyproject_inline_array_warns_and_skips(tmp_path, capsys):
+    """merge_pyproject_deps warns and returns 0 when dev array is inline,
+    leaving pyproject.toml byte-identical to the original."""
+    original = '[dependency-groups]\ndev = ["ruff>=0.14.1"]\n'
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(original, encoding="utf-8")
+
+    ret = merge_pyproject_deps(tmp_path, ["pytest>=8.0.0"], dry_run=False)
+
+    assert ret == 0
+    assert "WARN" in capsys.readouterr().out
+    assert pyproject.read_text(encoding="utf-8") == original
+
+
+def test_merge_gitignore_utf8(tmp_path):
+    """merge_gitignore reads and writes .gitignore files with UTF-8 encoding."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / ".gitignore").write_text("*.log\n.env\n", encoding="utf-8")
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    (dst / ".gitignore").write_text("*.pyc\n", encoding="utf-8")
+
+    merge_gitignore(dst, src, dry_run=False)
+
+    result = (dst / ".gitignore").read_text(encoding="utf-8")
+    assert "*.log" in result
+    assert ".env" in result
+    assert "*.pyc" in result

--- a/user-skills/research/scholar-labs-search/SKILL.md
+++ b/user-skills/research/scholar-labs-search/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: scholar-labs-search
+description: >-
+  Run academic literature searches on Google Scholar Labs through the user's
+  own authenticated Chrome, then extract the papers and citations found. Use
+  this whenever the user wants to search Google Scholar, find peer-reviewed
+  sources or citations for a claim, answer a research question with the
+  literature, or gather academic evidence, even if they don't name "Scholar
+  Labs" explicitly. Especially important because Scholar Labs has a strict
+  ~3-queries-per-day quota: this skill prevents wasting queries on malformed
+  searches and on re-reads that cost nothing. Do NOT use for general web
+  search, fetching one known URL, or reading a PDF the user already has.
+compatibility: Requires the playwright Python package and a Chromium-based browser the user can authenticate.
+---
+
+# Google Scholar Labs search
+
+Scholar Labs is Google's experimental AI-overview search over scholarly papers. It
+evaluates ~60-200 results per query and surfaces ~10 with structured summaries, which
+makes it excellent for finding peer-reviewed evidence quickly. Two constraints shape how
+to use it well:
+
+1. **It is quota-limited** (commonly ~3 queries/day per Google account). A wasted query is
+   expensive. Treat every search as scarce.
+2. **Authentication is the user's job.** Scholar Labs needs a logged-in Google session, and
+   automating Google login is fragile and against the spirit of the user-attended workflow.
+   So the human launches and authenticates the browser; this skill drives it afterward.
+
+Because of (1), the golden rule is: **never burn a query you didn't have to.** Re-reads are
+free (`--read-only`); only a fresh `--query` costs quota.
+
+## Step 1 - Decide whether Scholar Labs is even the right tool
+
+Reserve the scarce quota for questions that genuinely need *peer-reviewed* citations
+(empirical claims, healthcare/clinical evidence, "what does the literature show about X").
+For general definitions, vendor docs, news, or background, prefer ordinary web search or a
+deep-research tool and save the quota. Tell the user when you're deliberately *not* spending
+a Scholar query so they know the plan.
+
+## Step 2 - Have the user launch and authenticate Chrome (user-attended)
+
+Ask the user to run this (in Claude Code they can prefix with `!`), then log into Google in
+the window it opens:
+
+```
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --remote-debugging-port=9222 --user-data-dir="/tmp/chrome-debug" &
+```
+
+Then: open `https://scholar.google.com/scholar_labs/search?hl=en` in that window and sign in.
+
+Gotchas worth stating up front, because they silently waste the user's time:
+- If Chrome is **already running under their normal profile**, macOS routes the
+  `--remote-debugging-port` flag to the existing process and ignores it, so port 9222 stays
+  empty. Have them **Quit Chrome fully (Cmd-Q)** first. The throwaway `/tmp/chrome-debug`
+  profile keeps this separate from their everyday session.
+- Confirm the endpoint is live before doing anything else:
+  `curl -s http://localhost:9222/json | python3 -c "import sys,json;[print(t['title'],'|',t['url']) for t in json.load(sys.stdin) if t['type']=='page']"`
+  You want to see a `Google Scholar` tab on the `scholar_labs/search` URL.
+
+## Step 3 - Install the one dependency
+
+The bundled script attaches over CDP, so no browser download is needed, only the package:
+
+```
+uv pip install playwright   # or: pip install playwright
+```
+
+## Step 4 - Phrase the query for a retrieval engine
+
+Scholar Labs *retrieves papers*; it does not synthesize opinions. Compound or comparative
+questions ("do X reviewers outperform Y; also consider Z?") with semicolons tend to get
+**bounced** with "Scholar Labs is currently not designed for queries like this." Rephrase as
+a single focused retrieval ask.
+
+**Example 1:**
+Input: Empirical evidence that human experts detect and correct LLM errors in text-to-SQL; do reviewers outperform the model alone?
+Output: human-in-the-loop validation accuracy of AI-generated SQL queries
+
+**Example 2:**
+Input: What's the best way to define workforce agility and is it the same as IT agility or not?
+Output: definitions of workforce agility in organizational research
+
+Draft the queries, show them to the user, and get a thumbs-up *before* spending quota.
+
+## Step 5 - Run the search (this spends one query)
+
+Each fresh query starts a clean session automatically (the script navigates to the base
+search URL first, so a previous query cannot contaminate this one - a real failure mode of
+naive automation that reuses the open box).
+
+```
+uv run python ~/.claude/skills/scholar-labs-search/scripts/scholar_search.py --query "your focused query"
+```
+
+The script prints JSON: `{url, result_count, status, body, sources[]}`.
+- `status: "ok"` with a non-null `result_count` (e.g. 10) means real results.
+- `status: "bounced"` means rephrase (Step 4) - this still consumed a query, so pause and
+  fix the wording before retrying.
+- `status: "needs_auth"` / `"no_chrome"` means go back to Step 2.
+
+Out of quota? The user can sign into a **second Google account** and you re-run with
+`--authuser 1` for a fresh allotment.
+
+## Step 6 - The free re-read (use this constantly)
+
+Results render a beat *after* the page first updates. If an extraction looks empty or shows a
+stale "Found 0 / not designed for queries like this" block but the browser visibly has
+results, **do not re-query**. Re-read the live page for free:
+
+```
+uv run python ~/.claude/skills/scholar-labs-search/scripts/scholar_search.py --read-only
+```
+
+This is the single most important habit: a "0 results" from the script is often an early-read
+artifact, not the truth. Confirm by re-reading before you ever conclude a gap exists.
+
+## Step 7 - Record the results (follow the project's convention)
+
+This skill returns raw findings; recording them is project-specific. If the repo has a
+research-provenance system (an answers/ directory of `Research_*.md` files, a questions index,
+a rule that every claim traces to a source URL), write the findings there with full citation
+metadata and source URLs, and update the index. Otherwise, summarize the `sources[]` with
+their URLs for the user. Mark a question as a genuine literature *gap* only after a clean,
+non-bounced search returned nothing - never after a bounce or an early-read 0.
+
+## Quick reference
+
+| Need | Command | Quota |
+|------|---------|-------|
+| Check endpoint | `curl -s http://localhost:9222/json` | free |
+| New search | `scholar_search.py --query "..."` | 1 query |
+| Re-read current page | `scholar_search.py --read-only` | free |
+| Second account | add `--authuser 1` | 1 query (other account) |

--- a/user-skills/research/scholar-labs-search/scripts/scholar_search.py
+++ b/user-skills/research/scholar-labs-search/scripts/scholar_search.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 stharrold
+# SPDX-License-Identifier: Apache-2.0
+"""
+Google Scholar Labs search over a user-authenticated Chrome (CDP).
+
+This script attaches to a Chrome you launched with --remote-debugging-port
+(it does NOT launch or authenticate Chrome itself; Google auth is user-attended).
+It supports two modes:
+
+  --read-only            Extract results already on the current Scholar Labs tab.
+                         Costs ZERO quota. Use this to re-read a page whose results
+                         rendered after an earlier extraction fired too early.
+
+  --query "TEXT"         Start a FRESH session (navigates to the base search URL so
+                         the previous query can't contaminate this one), submit TEXT,
+                         wait for results to render, then extract. COSTS ONE QUERY of
+                         the Scholar Labs daily quota (typically 3/day per account).
+
+Output: JSON on stdout (or to --out FILE): {url, result_count, status, body, sources[]}.
+Each source is {title, url}. The script never writes Markdown answer files itself;
+the caller decides how to record results (project conventions vary).
+
+Examples:
+  uv run python scholar_search.py --read-only
+  uv run python scholar_search.py --query "human-in-the-loop validation accuracy of AI-generated SQL"
+  uv run python scholar_search.py --query "..." --authuser 1   # second Google account
+"""
+
+import argparse
+import asyncio
+import json
+import sys
+
+from playwright.async_api import async_playwright
+
+BASE = "https://scholar.google.com/scholar_labs/search?hl=en"
+
+
+def base_url(authuser):
+    return BASE if authuser is None else f"{BASE}&authuser={authuser}"
+
+
+async def _find_or_open(ctx, authuser):
+    for pg in ctx.pages:
+        if "scholar_labs" in pg.url:
+            return pg
+    pg = await ctx.new_page()
+    await pg.goto(base_url(authuser))
+    return pg
+
+
+async def _extract(page):
+    """Read-only: pull body text + external source anchors from the current page."""
+    body = await page.locator("body").inner_text()
+
+    # The page can show a stale '--query / Found 0 relevant results' sub-block from a
+    # prior search ABOVE the real one. Report the LAST 'Found N relevant results'.
+    result_count = None
+    for line in body.splitlines():
+        s = line.strip().lower()
+        if "relevant result" in s:
+            for tok in s.replace("found", "").split():
+                if tok.isdigit():
+                    result_count = int(tok)
+
+    status = "ok"
+    if "not designed for queries like this" in body.lower():
+        status = "bounced"  # rephrase needed (often a compound/comparative question)
+    if "sign in" in body.lower() and "scholar labs" not in body.lower():
+        status = "needs_auth"
+
+    sources, seen = [], set()
+    anchors = page.locator("a")
+    for i in range(await anchors.count()):
+        try:
+            href = await anchors.nth(i).get_attribute("href")
+            txt = (await anchors.nth(i).text_content() or "").strip()
+        except Exception:
+            continue
+        if not href or not href.startswith("http") or "google." in href:
+            continue
+        if len(txt) < 6 or txt.lower().startswith("[pdf]") or txt.lower().startswith("[html]"):
+            # the bare "[PDF] domain.com" anchors duplicate the titled ones; skip
+            continue
+        if href in seen:
+            continue
+        seen.add(href)
+        sources.append({"title": txt, "url": href})
+
+    return {"url": page.url, "result_count": result_count, "status": status, "body": body, "sources": sources}
+
+
+async def _submit_and_wait(page, query, authuser, timeout_s):
+    # Fresh session: navigate to base URL so the previous query cannot contaminate.
+    await page.goto(base_url(authuser))
+    box = page.locator("#gs_as_i_t, textarea, [role=combobox]").first
+    await box.wait_for(timeout=15000)
+    await box.fill(query)
+    await box.press("Enter")
+
+    # Poll until results render. 'Looking for results...' is the in-progress state.
+    waited = 0
+    while waited < timeout_s:
+        await page.wait_for_timeout(2000)
+        waited += 2
+        txt = (await page.locator("body").inner_text()).lower()
+        if "not designed for queries like this" in txt:
+            break
+        if "relevant result" in txt and "looking for results" not in txt:
+            break
+
+
+async def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("query", nargs="?", help="query text (positional; or use --query)")
+    ap.add_argument("--query", dest="query_flag", help="query text")
+    ap.add_argument("--read-only", action="store_true", help="extract current page only; spends NO quota")
+    ap.add_argument("--authuser", type=int, default=None, help="Google account index for a second account (quota reset)")
+    ap.add_argument("--port", type=int, default=9222)
+    ap.add_argument("--timeout", type=int, default=60, help="seconds to wait for results")
+    ap.add_argument("--out", help="write JSON here instead of stdout")
+    a = ap.parse_args()
+
+    query = a.query_flag or a.query
+    if not a.read_only and not query:
+        print("ERROR: provide a query, or pass --read-only.", file=sys.stderr)
+        sys.exit(2)
+
+    async with async_playwright() as p:
+        try:
+            browser = await p.chromium.connect_over_cdp(f"http://localhost:{a.port}")
+        except Exception:
+            print(json.dumps({"status": "no_chrome", "hint": f"Launch Chrome with --remote-debugging-port={a.port} and log into Google."}))
+            return
+        ctx = browser.contexts[0]
+        page = await _find_or_open(ctx, a.authuser)
+        await page.bring_to_front()
+
+        if not a.read_only:
+            await _submit_and_wait(page, query, a.authuser, a.timeout)
+
+        result = await _extract(page)
+
+    payload = json.dumps(result, indent=2)
+    if a.out:
+        with open(a.out, "w") as f:
+            f.write(payload)
+        print(f"wrote {a.out} (status={result['status']}, results={result['result_count']}, sources={len(result['sources'])})")
+    else:
+        print(payload)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/user-skills/workflow/branch-release.md
+++ b/user-skills/workflow/branch-release.md
@@ -1,0 +1,177 @@
+---
+name: branch-release
+description: Cut a release branch from develop, merge to main, tag, backmerge to develop, and rebase contrib/<user>. Run this when develop is ready to ship.
+---
+
+# Branch Release Skill
+
+Takes develop from "ready" to "tagged on main" and keeps all branches in sync.
+Four-stage flow: cut release → merge to main → backmerge to develop → rebase contrib.
+
+## Input
+
+The user may specify a version bump type: `patch`, `minor`, or `major`.
+If not specified, infer from the commits on develop since the last tag:
+- Any commit with `feat:` or `feat(...):`  → minor
+- Any commit with `BREAKING CHANGE` or `!:` → major
+- Otherwise → patch
+
+The user may also supply an explicit version (e.g. `v1.2.0`). If so, use it directly
+and skip the inference step.
+
+---
+
+## Checklist
+
+### Phase 1 -- Determine version
+
+```bash
+# Find the current highest semver tag
+git fetch --tags
+CURRENT=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+echo "Current tag: ${CURRENT}"
+```
+
+If no tags exist, start at `v0.1.0` (first release is always minor).
+
+Parse the version, apply the bump, and print the proposed next version:
+```
+Current : v1.2.3
+Bump    : minor
+Next    : v1.3.0
+```
+
+Ask the user to confirm the version before continuing if it was inferred
+(skip confirmation if the user supplied it explicitly).
+
+### Phase 2 -- Cut the release branch
+
+```bash
+git checkout develop
+git pull origin develop
+
+git checkout -b "release/v${NEXT}"
+git push -u origin "release/v${NEXT}"
+```
+
+### Phase 3 -- Merge release to main
+
+Create the PR:
+```bash
+gh pr create \
+  --repo <owner/repo> \
+  --base main \
+  --head "release/v${NEXT}" \
+  --title "release: v${NEXT}" \
+  --body "$(cat <<'EOF'
+## Release v${NEXT}
+
+Merging release/v${NEXT} into main.
+
+- Bump type: ${BUMP}
+- Base: develop @ $(git rev-parse --short HEAD)
+EOF
+)"
+```
+
+Then invoke `/pr-ship` behaviour for this PR:
+- Wait for CI (Phase 2 of pr-ship)
+- Fix any failures (Phase 3 of pr-ship)
+- Address reviewer comments (Phase 4 of pr-ship)
+- **Do NOT auto-merge** -- pause and tell the user the PR is ready,
+  then wait for explicit confirmation before merging.
+
+Reason: release merges to main are high-stakes; the user should click merge
+or give explicit approval ("go ahead") before this skill proceeds.
+
+After confirmed merge:
+
+```bash
+git checkout main
+git pull origin main
+```
+
+### Phase 4 -- Tag main
+
+```bash
+git tag "v${NEXT}" -m "release: v${NEXT}"
+git push origin "v${NEXT}"
+```
+
+Confirm the tag is visible:
+```bash
+git tag --sort=-v:refname | head -3
+```
+
+### Phase 5 -- Backmerge release to develop
+
+Create the backmerge PR:
+```bash
+gh pr create \
+  --repo <owner/repo> \
+  --base develop \
+  --head "release/v${NEXT}" \
+  --title "chore: backmerge v${NEXT} to develop" \
+  --body "Backmerge release/v${NEXT} into develop after main merge."
+```
+
+Wait for CI to pass, then merge:
+```bash
+gh pr merge <number> --repo <owner/repo> --merge --delete-branch
+```
+
+Use `--merge` (not `--squash`) for backmerges -- preserves the release commit
+on develop so git history is symmetric.
+
+If GitHub reports "No commits between develop and release/v${NEXT}" (nothing
+to backmerge), skip this step and note it in the summary.
+
+### Phase 6 -- Rebase contrib/<user> onto develop
+
+```bash
+git fetch origin develop
+git checkout contrib/<user>
+git pull origin contrib/<user>
+git rebase origin/develop
+git push --force-with-lease origin contrib/<user>
+```
+
+`--force-with-lease` is safe here: it aborts if the remote has commits you
+have not seen, protecting against accidentally overwriting someone else's push.
+
+If the rebase has conflicts:
+1. List the conflicting files.
+2. Resolve them (prefer develop's version for files that are part of the release;
+   prefer contrib's version for in-progress feature work).
+3. `git rebase --continue` after each conflict set.
+4. If the conflict is non-trivial, pause and surface it to the user.
+
+### Phase 7 -- Final report
+
+Print a summary:
+
+```
+Release complete
+---------------
+Version  : v${NEXT}
+Tag      : v${NEXT} on main ($(git rev-parse --short v${NEXT}))
+Backmerge: release/v${NEXT} -> develop  [merged | skipped]
+Contrib  : contrib/<user> rebased onto develop
+
+Branches now:
+  main            <- v${NEXT} (tagged)
+  develop         <- includes v${NEXT} backmerge
+  contrib/<user> <- rebased onto develop
+```
+
+---
+
+## Hard stops
+
+- Do not proceed past Phase 3 without explicit user confirmation of the merge.
+- Do not tag until `git pull origin main` confirms the release PR merged.
+- Do not use `--force` (without `-with-lease`) on any push.
+- If `develop` has uncommitted or unmerged feature work that should NOT be in
+  this release, stop and tell the user before cutting the release branch.
+- If the computed next version would be lower than the current highest tag
+  (e.g. user requests patch but CURRENT is already v2.0.0), pause and confirm.

--- a/user-skills/workflow/branch-start.md
+++ b/user-skills/workflow/branch-start.md
@@ -1,0 +1,120 @@
+---
+name: branch-start
+description: Create a timestamped feature branch and its own git worktree. Run this at the start of every new feature -- before writing any code.
+---
+
+# Branch Start Skill
+
+Creates a feature branch and an isolated git worktree for a single piece of work.
+The worktree keeps the main repo checkout clean while the feature is in progress.
+
+## Input
+
+The user must supply a short slug describing the feature. If they did not provide
+one, ask before proceeding:
+
+> "What's a short slug for this feature? (e.g. `add-ocr-engine`, `fix-model-download`)"
+
+Slugs use lowercase hyphens only. No underscores, no spaces, no uppercase.
+Strip the slug of any leading/trailing hyphens.
+
+---
+
+## Checklist
+
+### Step 1 -- Collect context
+
+Run these commands from the main repo checkout (not from inside a worktree):
+
+```bash
+# Confirm you are in the main repo, not a worktree
+git rev-parse --show-toplevel
+pwd
+
+# Repo name (used for the worktree directory)
+basename "$(git rev-parse --show-toplevel)"
+
+# Current branch (should be main, develop, or contrib/<user> -- not a feature branch)
+git branch --show-current
+
+# Confirm contrib/stharrold exists locally or on remote
+git branch -a | grep contrib/stharrold
+```
+
+If you are already inside a worktree (`pwd` differs from `--show-toplevel`):
+stop and tell the user. Branch creation must happen from the main checkout.
+
+If `contrib/stharrold` does not exist locally, fetch it:
+```bash
+git fetch origin contrib/stharrold:contrib/stharrold
+```
+
+### Step 2 -- Generate names
+
+```bash
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+echo "timestamp: ${TS}"
+```
+
+Compose the names:
+- **Branch**: `feature/${TS}_${SLUG}`  (e.g. `feature/20260605T163000Z_add-ocr-engine`)
+- **Worktree dir**: `../${REPO_NAME}_feature_${TS}_${SLUG}`
+  (e.g. `../claristra_feature_20260605T163000Z_add-ocr-engine`)
+
+Print both so the user can see them before any git commands run.
+
+### Step 3 -- Create the worktree and branch
+
+The feature branch starts from `contrib/stharrold` so the feature inherits
+any in-progress work that is already integrated but not yet on develop.
+
+```bash
+git worktree add \
+  "../${REPO_NAME}_feature_${TS}_${SLUG}" \
+  -b "feature/${TS}_${SLUG}" \
+  contrib/stharrold
+```
+
+Confirm success:
+```bash
+git worktree list
+```
+
+### Step 4 -- Push the branch to remote
+
+```bash
+cd "../${REPO_NAME}_feature_${TS}_${SLUG}"
+git push -u origin "feature/${TS}_${SLUG}"
+```
+
+### Step 5 -- Report and hand off
+
+Print a summary block the user can copy:
+
+```
+Worktree : ../${REPO_NAME}_feature_${TS}_${SLUG}
+Branch   : feature/${TS}_${SLUG}
+Base     : contrib/stharrold
+Remote   : pushed
+
+Next steps:
+  cd ../${REPO_NAME}_feature_${TS}_${SLUG}   # work here
+  /pr-ship                                    # when ready to merge
+```
+
+All subsequent work for this feature happens inside the worktree directory.
+The main repo checkout stays on its original branch and is undisturbed.
+
+---
+
+## Hard stops
+
+- Do not create a worktree if `git status` shows uncommitted changes in the main
+  repo -- commit or stash first.
+- Do not use `_` in slugs (worktree directory uses `_` as a separator between
+  the repo name, "feature", timestamp, and slug -- mixing in slug underscores
+  breaks that structure).
+- Do not create a feature branch from `main` or `develop` directly -- always
+  branch from `contrib/stharrold`.
+- If a worktree for this slug already exists (leftover from a previous attempt),
+  pause and ask the user whether to remove it or reuse it.

--- a/user-skills/workflow/pr-ship.md
+++ b/user-skills/workflow/pr-ship.md
@@ -1,0 +1,181 @@
+---
+name: pr-ship
+description: Push a feature branch, wait for CI, fix failures, address reviewer comments, merge, and clean up the merged worktree + local branch -- fully autonomous with pause points for judgment calls.
+---
+
+# PR Ship Skill
+
+Autonomously take a feature branch from "ready to push" to "merged". Works across
+any repo that uses GitHub Actions CI and gh CLI.
+
+## Checklist
+
+Work through each phase in order. Mark each task complete before moving to the next.
+Pause and surface to the user whenever a step requires judgment (see Phase 4).
+
+---
+
+### Phase 1 -- Ensure PR exists
+
+1. Run `git status` and `git branch --show-current` to confirm the working tree is
+   clean and you are on a feature branch.
+2. If there are uncommitted changes, commit them first (follow the repo's commit
+   conventions; check git log for style).
+3. Push the branch: `git push -u origin <branch>` (or just `git push` if tracking
+   is already set).
+4. Check whether a PR already exists:
+   `gh pr list --repo <owner/repo> --head <branch> --json number,url`
+   - If none exists: create one with `gh pr create --title "..." --body "..."`.
+     Use a HEREDOC for the body. Set base branch to develop (or main if no develop).
+   - If one exists: note its number and URL; proceed.
+5. Print the PR URL so it is visible in the conversation.
+
+---
+
+### Phase 2 -- Wait for CI
+
+Repeat until all checks complete (pass or fail) or 20 minutes have elapsed:
+
+```
+gh pr view <number> --repo <owner/repo> --json statusCheckRollup
+```
+
+- If status is QUEUED or IN_PROGRESS: wait 30 seconds, then check again.
+  Use a polling loop -- do NOT sleep longer than 30 s per iteration so you stay
+  responsive to early failures.
+- If all checks show SUCCESS: proceed to Phase 4.
+- If any check shows FAILURE: proceed to Phase 3.
+- If 20 minutes elapse with checks still running: pause and tell the user.
+
+---
+
+### Phase 3 -- Fix CI failures (loop back to Phase 2 when done)
+
+For each failing check:
+
+1. Get the run ID from the statusCheckRollup detailsUrl or:
+   `gh run list --repo <owner/repo> --branch <branch> --limit 5`
+2. Read the failure log:
+   `gh run view <run-id> --repo <owner/repo> --log-failed`
+3. Diagnose the root cause from the log. Common categories:
+   - **Compilation error**: fix the Swift/TS/Python source file directly.
+   - **Test failure**: read the test output, fix the failing assertion or the code
+     under test. Do NOT delete or skip tests to make CI pass.
+   - **Missing file / lock file**: generate and commit the missing artifact
+     (e.g. `npm install` for package-lock.json).
+   - **Build config error** (xcodegen, tsconfig, wrangler): fix the config file.
+   - **Flaky test / infrastructure timeout**: re-run once with
+     `gh run rerun <run-id> --repo <owner/repo>` before diagnosing further.
+4. Apply the fix, commit with a concise message, push.
+5. Return to Phase 2.
+
+If the same check fails 3 times with different error messages (indicating the fix
+is not converging): pause and explain the situation to the user before continuing.
+
+---
+
+### Phase 4 -- Address reviewer comments
+
+1. Fetch all open PR review comments:
+   ```
+   gh api repos/<owner/repo>/pulls/<number>/comments \
+     --jq '.[] | {id, path, line, body}'
+   ```
+   Also fetch top-level review bodies:
+   ```
+   gh pr view <number> --repo <owner/repo> --json reviews \
+     --jq '.reviews[] | {author: .author.login, state, body}'
+   ```
+
+2. For each comment, classify it:
+
+   **Mechanical** (fix autonomously):
+   - OOM / memory / performance fix with a clear correct approach
+   - Stale / misleading comment in code
+   - Deprecated API swap with obvious replacement
+   - Missing null check, defer, error cleanup
+   - Trailing slash, copy/paste bug, typo
+   - Test coverage gap with an obvious test to add
+
+   **Judgment required** (pause and surface to user):
+   - Architecture or design disagreement
+   - Request to change a tradeoff that was deliberately chosen
+   - Ambiguous requirement ("make this more robust")
+   - Comment that conflicts with a decision recorded in CLAUDE.md or a resolved OD
+   - Any comment you are not confident you can fix correctly in one pass
+
+3. Apply all mechanical fixes. Group logically related fixes into a single commit.
+   Push. Return to Phase 2 to let CI verify the fixes.
+
+4. For judgment-required comments: list them clearly (file, line, comment text,
+   why you are pausing) and wait for the user before continuing.
+
+---
+
+### Phase 5 -- Merge
+
+Only proceed when:
+- All CI checks show SUCCESS (re-run Phase 2 to confirm after the last push).
+- No open reviewer comments remain that you have not addressed or escalated.
+
+Merge:
+```
+gh pr merge <number> --repo <owner/repo> --squash --delete-branch
+```
+
+Use `--squash` unless the repo's CLAUDE.md or branch conventions specify otherwise
+(e.g. some repos prefer `--merge` to preserve individual commits).
+
+After merging, confirm with:
+```
+gh pr view <number> --repo <owner/repo> --json state,mergedAt
+```
+
+Print the merge confirmation so it is visible in the conversation.
+
+---
+
+### Phase 6 -- Clean up the merged feature branch
+
+`--delete-branch` removes the REMOTE branch, but feature work here lives in a git
+worktree, so two things linger and accumulate: the worktree directory and the local
+branch (a branch checked out in a worktree cannot be deleted by `--delete-branch`).
+After the merge is confirmed MERGED, clean both up -- from the repo's MAIN checkout,
+since you cannot remove the worktree you are standing in:
+
+```
+# cd to the main checkout first if cwd is inside the feature worktree
+git worktree remove <path-to-feature-worktree>   # no --force: refuses if dirty
+git branch -d <feature-branch>                    # safe -d: refuses if unmerged
+```
+
+Safety (do not weaken):
+- Use `git branch -d`, never `-D`. If `-d` refuses, the branch has commits not in
+  the merge target (e.g. work committed after the PR head merged) -- STOP and report
+  it; do not force-delete (those commits may exist only on this branch).
+- Use `git worktree remove` without `--force`. If it refuses (uncommitted or
+  untracked files), report the path for manual review instead of forcing.
+- Clean up ONLY the just-merged branch here -- never batch-delete other branches.
+
+---
+
+## Hard stops (always pause, never skip)
+
+- The user has explicitly said a comment requires their input in CLAUDE.md or earlier
+  in the conversation.
+- Fixing a CI failure would require deleting or skipping a test.
+- The fix touches a file the user marked as off-limits or out of scope.
+- The PR branch has diverged from its base (merge conflict): resolve or rebase, then
+  confirm with the user before pushing a force-push equivalent.
+- The PR targets main directly and the repo has a protect rule -- check first.
+
+## Tips
+
+- Always use `--repo <owner/repo>` on every `gh` command to avoid acting on the
+  wrong repo when worktrees or multiple remotes are involved.
+- `gh run view --log-failed` only shows the failed steps. Use `--log` (full log)
+  only when --log-failed is not enough to diagnose.
+- If CI checks have not appeared yet after a push, wait 15 s and re-poll --
+  GitHub takes a moment to enqueue checks.
+- Do not amend published commits. Always create new commits when fixing CI failures
+  on an open PR.

--- a/user-skills/workflow/release-pilot/SKILL.md
+++ b/user-skills/workflow/release-pilot/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: release-pilot
+description: >-
+  Autonomously drive a Python repo's release end to end through the
+  contrib -> develop -> release -> main branch topology, with review/CI
+  gates and an explicit human confirm before promoting to production.
+  Use when the user says "cut a release", "ship this", "run the release
+  pilot", "release vN.N.N", or asks to drive a PR through to main. Derives
+  all phase/progress from git state -- no TODO files, no state database.
+---
+
+# release-pilot
+
+Declarative playbook for driving a release. This skill is **policy and
+topology**; the engine is built-in tooling (native worktrees, `/loop`,
+`/code-review`, and the `superpowers` skills). Do not re-implement
+orchestration in code -- read the git state, decide the next step, act.
+
+## When this applies
+
+Use when piloting a change from a working branch all the way to a tagged
+`main` release. Skip for a single quick commit, or work that never leaves a
+feature branch.
+
+## Branch topology (authoritative)
+
+```
+release/<YYYYMMDDTHHMMSSZ>_<slug>   <- work branch (worktree); implementation
+   |  PR + gate-merge (autonomous)
+   v
+contrib/<user>
+   |  rebase onto develop, then PR + gate-merge (autonomous)
+   v
+develop
+   |  ===== EXPLICIT HUMAN CONFIRM REQUIRED =====
+   v
+release/vN.N.N                     <- version branch
+   |  PR + merge to main (confirm-gated), then tag vN.N.N on main
+   v
+main  (tag vN.N.N)
+   |  backmerge release/vN.N.N -> develop (autonomous)
+   v
+develop  ->  rebase contrib/<user> onto develop
+```
+
+Two distinct `release/*` namespaces -- keep them straight:
+
+- **Work branch** `release/<YYYYMMDDTHHMMSSZ>_<slug>`: timestamped, one per
+  change. Where code is written. Replaces the old `feature/*`.
+- **Version branch** `release/vN.N.N`: the production-promotion branch cut
+  from `develop`. Created only after the confirm gate.
+
+`<slug>` is hyphenated lowercase. Timestamp is UTC `date -u +%Y%m%dT%H%M%SZ`.
+
+## The gates (decided contract)
+
+| Gate | Type | Behavior |
+|---|---|---|
+| **Human reviews** | soft, 10-min ceiling | Poll `gh pr view <pr> --json reviews,reviewDecision` and unresolved threads. Address any review that arrives. **If none arrive within 10 minutes, proceed with the merge (merge-on-timeout). Do not block.** |
+| **CI checks** | hard | `gh pr checks <pr>` must be green (all required checks) before any merge, including the merge-on-timeout case. **On failure: auto-fix, repush, re-poll.** |
+| **`develop -> release -> main` promotion** | confirm | Stop and require explicit human confirmation before creating `release/vN.N.N`, merging to `main`, or tagging. This gate is confirm-driven -- it never auto-proceeds on a timeout. |
+
+Autonomy boundary: everything up to and including the merge into `develop`
+is autonomous (including merge-on-timeout). The production promotion is
+human-gated.
+
+### Polling, not sleeping
+
+Drive the 10-minute review window with `/loop` (self-paced) or repeated
+`gh pr checks <pr>` calls at ~60-270s cadence -- never a single fixed
+`sleep`. The 10 minutes is a **ceiling that ends early** the moment reviews
+land or CI goes green; it is not a mandatory wait.
+
+### Verify the gate; never trust a masked exit code (learned in #241)
+
+`gh pr checks <pr> --watch` returns non-zero on check failure -- but only
+if you read *its* exit code. **Never pipe it into `tail`/`head`**: the
+pipeline's status is the last command's (`tail`), so `$?` is always 0 and a
+network drop (`TLS handshake timeout`) silently reads as "all green". This
+masked a false pass during the first real run.
+
+Rules:
+- Capture gh's own exit: `gh pr checks <pr> --watch >log 2>&1; echo $?` (no
+  pipe), or check `${PIPESTATUS[0]}`.
+- A `--watch` that exits is a *hint*, not proof. Before any merge,
+  **re-verify each check's conclusion explicitly** with `gh pr checks <pr>`
+  and confirm `mergeStateStatus == CLEAN`. A watch that died on a network
+  error is "unknown", not "pass".
+
+### CI auto-fix loop
+
+On a red required check:
+1. Read the failing check's logs (`gh run view <run-id> --log-failed`).
+2. Fix in the worktree (lint/format via the repo's tooling; real test/build
+   breaks via `systematic-debugging`).
+3. Commit, push, re-poll. Repeat until green or clearly stuck (then stop and
+   report).
+
+## The sequence
+
+Determine the current step from git state (see Recovery), then execute from
+there. Do not restart from step 1 if a later branch/PR/tag already exists.
+
+1. **Worktree.** Create a worktree on `release/<ts>_<slug>` branched from
+   `contrib/<user>` (native worktree tooling or `using-git-worktrees`).
+2. **Implement.** Do the work in the worktree. For code changes use
+   `test-driven-development`; commit in logical units.
+3. **Self-review.** Run `/code-review` on the diff; address findings.
+4. **PR to contrib.** Open `release/<ts>_<slug> -> contrib/<user>`. Apply
+   the review soft-gate + CI hard-gate, then merge (autonomous).
+5. **Integrate to develop.** Rebase `contrib/<user>` onto `develop` if
+   behind; open `contrib/<user> -> develop`; gate-merge (autonomous).
+6. **=== CONFIRM GATE ===** Compute the next `vN.N.N` with the deterministic
+   `release-lib` helper `next_version_from_tag(base_branch="origin/main",
+   ref="origin/main")` -- diffing develop against `origin/main` captures
+   everything unreleased; using `base_branch="develop"` when HEAD is already
+   on develop produces an empty diff and freezes the version. Never guess the version. **Sanity-check the bump:**
+   the file-pattern heuristic only treats `src/**.py` as a feature, so a new
+   top-level package (e.g. `release_lib/`) is under-classified as PATCH when
+   it is really a MINOR -- flag the mismatch and offer the override. Present
+   the proposed version + the `origin/main...origin/develop` diff summary and
+   **wait for explicit human confirmation.**
+7. **Version branch + main.** Create `release/vN.N.N` from `develop`; bump
+   `pyproject.toml` to the chosen version and run `uv lock` so `uv.lock`
+   doesn't drift (commit both); open `release/vN.N.N -> main`; merge only
+   after confirm; then create an **annotated** tag `vN.N.N` on the merge
+   commit and push it.
+8. **Backmerge.** Open/merge `release/vN.N.N -> develop` (autonomous gate).
+9. **Re-sync contrib.** Rebase `contrib/<user>` onto `develop`.
+10. **Clean up.** Remove the worktree; delete the merged `release/*` branches
+    locally and on the remote.
+
+## Recovery (resume from git state, never from a file)
+
+Phase is a pure function of git observables. To resume, check in order:
+
+- Tag `vN.N.N` on `main` exists + open `release/vN.N.N -> develop` PR ->
+  step 8 (backmerge) or step 9 (re-sync contrib).
+- `release/vN.N.N` exists + open PR to `main` -> step 7 (awaiting confirm
+  has passed; finish merge/tag).
+- Open `contrib/<user> -> develop` PR -> step 5.
+- Open `release/<ts>_<slug> -> contrib` PR -> step 4.
+- Work branch exists, no PR -> step 3.
+- Detached HEAD or nothing in flight -> report state, ask the user; do not
+  guess.
+
+Do **not** create or read `TODO_*.md` or any AgentDB/DuckDB state. Those are
+deprecated; git + the GitHub PR/checks API are the only source of truth.
+
+## Built-ins this skill drives (don't reinvent)
+
+| Need | Use |
+|---|---|
+| Isolated worktree | native worktree tooling / `superpowers:using-git-worktrees` |
+| Review-window / CI polling | `/loop` (self-paced) |
+| Self-review a diff | `/code-review` |
+| Acting on review feedback | `superpowers:receiving-code-review` |
+| Finishing/merging a branch | `superpowers:finishing-a-development-branch` |
+| Verifying before "done" | `superpowers:verification-before-completion` |
+| Next version (deterministic) | `release-lib` semver helper (Tier 2, issue #240) |
+
+## Anti-patterns
+
+- A fixed `sleep` for the review window (use a polling ceiling).
+- Merging to `main`, creating `release/vN.N.N`, or tagging without explicit
+  confirm.
+- Merging on red required CI (CI is a hard gate even on review timeout).
+- Computing the next version by judgment instead of the semver helper.
+- Writing `TODO_*.md` / touching AgentDB to track progress.
+- Re-deriving phase from anything other than git + PR/checks state.

--- a/uv.lock
+++ b/uv.lock
@@ -1003,7 +1003,7 @@ wheels = [
 
 [[package]]
 name = "stharrold-templates"
-version = "9.1.1"
+version = "9.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Release v9.2.0

### What's in this release

**New feature: user-level skill tracking** (`user-skills/` + `scripts/install_user_skills.py`)
- `user-skills/workflow/`: release-pilot, branch-release.md, branch-start.md, pr-ship.md
- `user-skills/research/`: scholar-labs-search skill + scripts
- `install_user_skills.py`: `--bundle workflow|research|all`, skip-on-update, `--force`, `--target`, `--dry-run`
- WORKFLOW.md, BUNDLES.md, README.md updated with install instructions

**Bug fixes: `release_lib.bundles` robustness** (#245)
- `copy_tree`: handles file-at-dst (was crashing with `rmtree` on a file)
- `_insert_deps_into_array`: breaks on cross-section bleed when dev array is inline; returns `bool`
- `merge_pyproject_deps`: warns+skips on inline array; post-write `tomllib` validation; `encoding="utf-8"`
- `merge_gitignore`: `encoding="utf-8"` on all file I/O
- 4 new unit tests; 283/283 pass

**Docs** (#243): BUNDLES.md / WORKFLOW.md / README.md / CLAUDE.md reframed around three-tier model

### Bump rationale

MINOR (9.1.1 → 9.2.0): `user-skills/` tracking system is a new user-facing capability; semver helper under-classified as PATCH because files land outside `src/`.

## Test plan
- [ ] CI green on this PR
- [ ] Tag `v9.2.0` on merge commit after merge
- [ ] Backmerge `release/v9.2.0 -> develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)