### PR TITLE
chore(backmerge): release/v9.2.0 -> develop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "stharrold-templates"
-version = "9.1.1"
+version = "9.2.0"
 description = "Templates and utilities for MCP server configuration and agentic development workflows"
 requires-python = ">=3.12"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -1003,7 +1003,7 @@ wheels = [
 
 [[package]]
 name = "stharrold-templates"
-version = "9.1.1"
+version = "9.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Backmerge release/v9.2.0 into develop after tagging v9.2.0 on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)